### PR TITLE
fix(release): build Linux .so targeting glibc 2.17 via zig cc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install build wheel setuptools
 
+      - name: Install Zig (Linux, for glibc 2.17 target)
+        if: runner.os == 'Linux'
+        run: |
+          ZIG_VERSION=0.13.0
+          wget -q "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+          tar xf "zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+          ZIG="$PWD/zig-linux-x86_64-${ZIG_VERSION}/zig"
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/bin/sh\nexec "%s" cc -target x86_64-linux-gnu.2.17 "$@"\n' "$ZIG" > "$HOME/.local/bin/zcc"
+          chmod +x "$HOME/.local/bin/zcc"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Build Go shared library (Linux)
         if: runner.os == 'Linux'
+        env:
+          CC: zcc
         run: |
           cd golang
           mkdir -p ../cycletls/dist


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- The Linux wheel was compiled against glibc 2.32+ (ubuntu-latest), making it incompatible with Debian Bullseye (glibc 2.31) and similar older distros still in production.

  Use zig cc with `-target x86_64-linux-gnu.2.17` as the CGO compiler so the resulting libcycletls.so works on any Linux with glibc >= 2.17.


## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/python-package-template/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/python-package-template/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
