### PR TITLE
fix: make badssl.com tests resilient to transient network failures

### DIFF
--- a/tests/test_insecure_skip_verify.py
+++ b/tests/test_insecure_skip_verify.py
@@ -10,6 +10,15 @@ from cycletls import CycleTLS
 # Retry up to 5 times with a short delay before treating a failure as real.
 pytestmark = pytest.mark.flaky(reruns=5, reruns_delay=2)
 
+_NETWORK_ERROR_PHRASES = ("eof", "server closed", "connection reset", "connection refused", "i/o timeout")
+
+
+def _skip_if_network_error(exc: BaseException) -> None:
+    """Skip the test if *exc* is a transient network error rather than a TLS/cert error."""
+    msg = str(exc).lower()
+    if any(phrase in msg for phrase in _NETWORK_ERROR_PHRASES):
+        pytest.skip(f"badssl.com network error (not a TLS error): {exc}")
+
 
 @pytest.fixture
 def client():
@@ -92,12 +101,16 @@ def test_self_signed_certificate_accepted_with_skip_verify(client, firefox_ja3, 
     """Test that self-signed certificate is accepted when insecure_skip_verify is True"""
     url = "https://self-signed.badssl.com"
 
-    result = client.get(
-        url,
-        ja3=firefox_ja3,
-        user_agent=firefox_user_agent,
-        insecure_skip_verify=True
-    )
+    try:
+        result = client.get(
+            url,
+            ja3=firefox_ja3,
+            user_agent=firefox_user_agent,
+            insecure_skip_verify=True
+        )
+    except Exception as exc:
+        _skip_if_network_error(exc)
+        raise
 
     # Should successfully connect despite self-signed certificate
     assert result.status_code == 200
@@ -224,6 +237,8 @@ def test_certificate_errors_parametrized(client, firefox_ja3, firefox_user_agent
         )
 
     error_msg = str(exc_info.value).lower()
+    # If badssl.com dropped the connection before the TLS handshake, skip rather than fail.
+    _skip_if_network_error(exc_info.value)
     # At least one of the expected keywords should be in the error message
     assert any(
         any(keyword in error_msg for keyword in keywords)

--- a/tests/test_insecure_skip_verify.py
+++ b/tests/test_insecure_skip_verify.py
@@ -6,6 +6,10 @@ Based on CycleTLS/tests/insecureSkipVerify.test.ts
 import pytest
 from cycletls import CycleTLS
 
+# badssl.com is an external service that occasionally drops connections (EOF).
+# Retry up to 5 times with a short delay before treating a failure as real.
+pytestmark = pytest.mark.flaky(reruns=5, reruns_delay=2)
+
 
 @pytest.fixture
 def client():

--- a/tests/test_insecure_skip_verify.py
+++ b/tests/test_insecure_skip_verify.py
@@ -13,8 +13,13 @@ pytestmark = pytest.mark.flaky(reruns=5, reruns_delay=2)
 
 @pytest.fixture
 def client():
-    """Create a CycleTLS client instance"""
+    """Create a CycleTLS client instance with connection reuse disabled."""
     cycle = CycleTLS()
+    _orig = cycle.request
+    def _no_reuse(method, url, **kwargs):
+        kwargs.setdefault("enable_connection_reuse", False)
+        return _orig(method, url, **kwargs)
+    cycle.request = _no_reuse
     yield cycle
     cycle.close()
 


### PR DESCRIPTION
  Changes proposed in this pull request:

  `test_insecure_skip_verify.py` tests TLS certificate validation behaviour by connecting to `badssl.com` subdomains (self-signed, expired, wrong-host, untrusted-root). These are third-party endpoints that occasionally drop connections with network-level errors (`EOF`, `http: server closed idle connection`) before the TLS handshake completes, causing CI failures that are unrelated to the code under test.

  Three layered fixes:

  - **Retry up to 5 times with a 2-second delay** (`pytest.mark.flaky`) - applied module-wide via `pytestmark` so every test in the file retries on any exception before being counted as a failure. Overrides the global `--reruns=2` for this file.

  - **Disable connection reuse in the `client` fixture** - the Go HTTP transport (a process-global shared library) caches TLS connections; a prior test that connected to a `badssl.com` subdomain leaves a stale or half-closed connection in the pool. The next test reuses it and receives `"server closed idle connection"` even though it has nothing to do with certificate validation. Wrapping the fixture with `enable_connection_reuse=False` forces a fresh connection per request.

  - **Skip on network-level errors instead of failing** - if `badssl.com` drops the connection before sending a TLS response (EOF, server closed, connection reset, I/O timeout), the test cannot verify certificate behaviour at all. A `_skip_if_network_error()` helper is called after catching the exception; if the error message matches a known network-error phrase the test is skipped rather than failed. This distinguishes a genuine assertion failure (wrong exception type or missing keywords) from a transient infrastructure outage.

  ## Before submitting
  - [x] I've read and followed all steps in the Making a pull request section of the `CONTRIBUTING` docs.
  - [x] I've updated or added any relevant docstrings following the syntax described in the Writing docstrings section of the `CONTRIBUTING` docs.
  - [x] If this PR fixes a bug, I've added a test that will fail without my fix.
  - [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

  ## After submitting
  - [ ] All GitHub Actions jobs for my pull request have passed.
