### PR TITLE
fix(tests): mark badssl.com tests as live; fix CHANGELOG fetch-depth

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Check that CHANGELOG has been updated
       run: |

--- a/tests/test_insecure_skip_verify.py
+++ b/tests/test_insecure_skip_verify.py
@@ -4,6 +4,7 @@ Based on CycleTLS/tests/insecureSkipVerify.test.ts
 """
 
 import pytest
+
 from cycletls import CycleTLS
 
 # badssl.com is an external service that occasionally drops connections (EOF).
@@ -97,6 +98,7 @@ def test_self_signed_certificate_error_without_skip_verify(client, firefox_ja3, 
     assert any(word in error_msg for word in ['certificate', 'verify', 'self-signed', 'authority', 'x509'])
 
 
+@pytest.mark.live
 def test_self_signed_certificate_accepted_with_skip_verify(client, firefox_ja3, firefox_user_agent):
     """Test that self-signed certificate is accepted when insecure_skip_verify is True"""
     url = "https://self-signed.badssl.com"
@@ -221,7 +223,11 @@ def test_connection_refused_error_handling(client, firefox_ja3, firefox_user_age
 
 @pytest.mark.parametrize("url,expected_error_keywords", [
     ("https://expired.badssl.com", ["certificate", "expired"]),
-    ("https://self-signed.badssl.com", ["certificate", "self-signed", "authority"]),
+    pytest.param(
+        "https://self-signed.badssl.com",
+        ["certificate", "self-signed", "authority"],
+        marks=pytest.mark.live,
+    ),
     ("https://wrong.host.badssl.com", ["certificate", "hostname", "name"]),
     ("https://untrusted-root.badssl.com", ["certificate", "untrusted", "authority"]),
 ])


### PR DESCRIPTION
## Summary
- Mark `test_self_signed_certificate_accepted_with_skip_verify` and the badssl.com case of `test_certificate_errors_parametrized` as `@pytest.mark.live` so they only run in the dedicated Live Tests workflow, not in blocking Unit Tests CI.
- Fix `pr_checks.yml` CHANGELOG step to use `fetch-depth: 0` so `origin/main` ref is available for diff comparison (previously `fetch-depth: 1` caused `fatal: Not a valid object name origin/main`).

## Why
These two tests hit `https://self-signed.badssl.com` which is consistently flaky in CI (intermittent EOF / "server closed idle connection" failures). They have been blocking unrelated PRs. Precedent for marking flaky network tests as `live`: commit 27ea362.

## Test Plan
- [x] `uv run pytest tests/test_insecure_skip_verify.py --collect-only -m "not live"` — affected tests are deselected
- [x] `uv run pytest tests/test_insecure_skip_verify.py --collect-only -m live` — affected tests are selected
- [x] `uv run ruff check tests/test_insecure_skip_verify.py && uv run ruff format --check tests/test_insecure_skip_verify.py`