### PR TITLE
feat(tests): run live tests against local tlsfingerprint.com Docker instance

### DIFF
--- a/.github/workflows/blocking-tests.yml
+++ b/.github/workflows/blocking-tests.yml
@@ -40,5 +40,46 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras --dev
 
+      - name: Checkout Danny-Dasilva/tlsfingerprint.com
+        uses: actions/checkout@v4
+        with:
+          repository: Danny-Dasilva/tlsfingerprint.com
+          ref: master
+          path: .tlsfingerprint-server
+
+      - name: Generate TLS certificates and config
+        working-directory: .tlsfingerprint-server
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:4096 \
+            -keyout certs/key.pem \
+            -out certs/chain.pem \
+            -sha256 -days 365 -nodes \
+            -subj "/CN=localhost" \
+            -addext "subjectAltName=IP:127.0.0.1,DNS:localhost"
+          jq '.log_to_db = false | .mongo_url = "" | .device = ""' \
+            config.example.json > config.json
+          cat /etc/ssl/certs/ca-certificates.crt certs/chain.pem > /tmp/combined-test-cas.crt
+
+      - name: Build and start tlsfingerprint.com server
+        working-directory: .tlsfingerprint-server
+        run: |
+          docker compose up -d --build
+          echo "Waiting for tlsfingerprint.com server to become ready..."
+          if ! timeout 90 bash -c 'until curl -sk --max-time 3 https://localhost/api/clean -o /dev/null; do sleep 2; done'; then
+            echo "Server did not become ready in time. Container logs:"
+            docker compose logs
+            exit 1
+          fi
+          echo "tlsfingerprint.com server is ready."
+
       - name: Run blocking tests
+        env:
+          TLSFP_URL: https://localhost
+          SSL_CERT_FILE: /tmp/combined-test-cas.crt
         run: uv run pytest -v --color=yes -m "blocking" tests/
+
+      - name: Tear down tlsfingerprint.com server
+        if: always()
+        working-directory: .tlsfingerprint-server
+        run: docker compose down -v || true

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -40,5 +40,49 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras --dev
 
+      - name: Checkout Danny-Dasilva/tlsfingerprint.com
+        uses: actions/checkout@v4
+        with:
+          repository: Danny-Dasilva/tlsfingerprint.com
+          ref: master
+          path: .tlsfingerprint-server
+
+      - name: Generate TLS certificates and config
+        working-directory: .tlsfingerprint-server
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:4096 \
+            -keyout certs/key.pem \
+            -out certs/chain.pem \
+            -sha256 -days 365 -nodes \
+            -subj "/CN=localhost" \
+            -addext "subjectAltName=IP:127.0.0.1,DNS:localhost"
+          # Disable mongo logging and clear mongo_url so the server doesn't try to connect to a DB.
+          jq '.log_to_db = false | .mongo_url = "" | .device = ""' \
+            config.example.json > config.json
+          # Combine system CAs with the test CA so the Go transport (and any tooling)
+          # trusts our self-signed cert via SSL_CERT_FILE.
+          cat /etc/ssl/certs/ca-certificates.crt certs/chain.pem > /tmp/combined-test-cas.crt
+
+      - name: Build and start tlsfingerprint.com server
+        working-directory: .tlsfingerprint-server
+        run: |
+          docker compose up -d --build
+          echo "Waiting for tlsfingerprint.com server to become ready..."
+          if ! timeout 90 bash -c 'until curl -sk --max-time 3 https://localhost/api/clean -o /dev/null; do sleep 2; done'; then
+            echo "Server did not become ready in time. Container logs:"
+            docker compose logs
+            exit 1
+          fi
+          echo "tlsfingerprint.com server is ready."
+
       - name: Run live tests
+        env:
+          TLSFP_URL: https://localhost
+          SSL_CERT_FILE: /tmp/combined-test-cas.crt
         run: uv run pytest -v --color=yes --reruns=3 -m "live and not blocking" tests/
+
+      - name: Tear down tlsfingerprint.com server
+        if: always()
+        working-directory: .tlsfingerprint-server
+        run: docker compose down -v || true

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -17,9 +17,13 @@ env:
 
 jobs:
   live-tests:
-    name: Live Tests (Python 3.12)
+    name: Live Tests (Python ${{ matrix.python }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v6
@@ -30,7 +34,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python }}
           enable-cache: true
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ site/
 
 # Continuous Claude cache (local only)
 .claude/cache/
+
+# Local checkout of Danny-Dasilva/tlsfingerprint.com used by live-tests workflow
+.tlsfingerprint-server/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,60 @@
+# CycleTLS Python Tests
+
+## Quick start
+
+```bash
+uv sync --all-extras --dev
+uv run pytest -m "not live" tests/        # offline, no external deps
+uv run pytest -m live tests/               # hits https://tls.peet.ws by default
+```
+
+## Live tests against a local tlsfingerprint.com Docker instance
+
+Live tests target `https://tls.peet.ws` by default. To run them against a
+local instance of [Danny-Dasilva/tlsfingerprint.com](https://github.com/Danny-Dasilva/tlsfingerprint.com)
+(the open-source server behind `tls.peet.ws`), bring up a local container and
+point the suite at it via the `TLSFP_URL` env var. CI does this automatically;
+locally:
+
+```bash
+# 1. Clone the server into a sibling directory
+git clone https://github.com/Danny-Dasilva/tlsfingerprint.com.git
+cd tlsfingerprint.com
+
+# 2. Generate self-signed certs
+mkdir -p certs
+openssl req -x509 -newkey rsa:4096 \
+    -keyout certs/key.pem -out certs/chain.pem \
+    -sha256 -days 365 -nodes \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=IP:127.0.0.1,DNS:localhost"
+
+# 3. Create config.json with DB logging disabled
+jq '.log_to_db = false | .mongo_url = "" | .device = ""' \
+    config.example.json > config.json
+
+# 4. Boot it (binds 80/443; needs sudo on most distros)
+docker compose up -d --build
+
+# 5. Trust the cert and run the live tests against the local server
+cd ../cycletls_python
+cat /etc/ssl/certs/ca-certificates.crt \
+    ../tlsfingerprint.com/certs/chain.pem > /tmp/combined-test-cas.crt
+TLSFP_URL=https://localhost SSL_CERT_FILE=/tmp/combined-test-cas.crt \
+    uv run pytest -v -m live tests/
+```
+
+If `TLSFP_URL` is unset, the suite falls back to `https://tls.peet.ws`.
+
+## Markers
+
+- `live` — exercises a real fingerprint server (`tls.peet.ws` or local).
+- `blocking` — CI-critical fingerprint validation; subset of `live`.
+
+## Connection reuse note
+
+`tls.peet.ws` and the local tlsfingerprint.com container both close the TLS
+connection after each response. The CycleTLS Go transport caches connections
+globally, so a closed connection can leak into the next test as
+`use of closed network connection`. Most fixtures default
+`enable_connection_reuse=False` to avoid this.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,17 @@ def cycletls_client():
     """
     Session-scoped CycleTLS client fixture.
     Creates a single client instance for all tests.
+
+    Connection reuse is disabled by default so that TrackMe-style servers
+    (which close connections after every response) don't leave a stale cached
+    connection in the global Go transport pool for the next test.
     """
     client = CycleTLS()
+    _orig = client.request
+    def _no_reuse(method, url, **kwargs):
+        kwargs.setdefault("enable_connection_reuse", False)
+        return _orig(method, url, **kwargs)
+    client.request = _no_reuse
     yield client
     client.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ import pytest
 import sys
 import os
 
+# TrackMe base URL — override with TRACKME_URL env var to point at a local instance
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+
 # Add parent directory to path to import cycletls
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -37,13 +40,19 @@ def cycletls_client_function():
 @pytest.fixture
 def test_url():
     """Base test URL for most tests."""
-    return "https://tls.peet.ws/api/clean"
+    return f"{_TRACKME_URL}/api/clean"
 
 
 @pytest.fixture
 def ja3_test_url():
     """TLS fingerprint test URL (replacement for defunct ja3er.com)."""
-    return "https://tls.peet.ws/api/clean"
+    return f"{_TRACKME_URL}/api/clean"
+
+
+@pytest.fixture(scope="session")
+def trackme_url():
+    """TrackMe base URL. Set TRACKME_URL env var to point at a local instance."""
+    return _TRACKME_URL
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ pytest configuration and shared fixtures for CycleTLS tests.
 """
 
 import os
+import re
 import sys
 
 import pytest
@@ -113,3 +114,128 @@ async def async_cycletls_client_function():
     client = AsyncCycleTLS()
     yield client
     await client.close()
+
+
+# ==============================================================================
+# JA4_r structural matchers (shared across test modules)
+# ==============================================================================
+#
+# JA4_r header format: t<TLS_ver>d<cipher_count><ext_count><ALPN>
+# Per the JA4 spec, cipher_count and ext_count are 2-digit zero-padded.
+# Production tls.peet.ws emits an unpadded form (e.g. "t12d128h2" for 12+8),
+# while local tlsfingerprint.com Docker emits the spec form ("t12d1208h2").
+# Both are accepted: helpers validate STRUCTURE rather than exact prefixes.
+
+_JA4R_HEADER_RE = re.compile(r"^t(?P<ver>\d{2})d(?P<counts>\d+)(?P<alpn>h2|h1|http)$")
+
+
+def _decode_counts(counts: str, observed_cipher_count: int) -> tuple[int, int]:
+    """
+    Decode the concatenated cipher_count + ext_count field from a JA4_r
+    header. Returns (cipher_count, ext_count).
+
+    Strategy: enumerate every (cc, ec) split where cc is a prefix of
+    `counts`, prefer the split where cc equals the observed cipher count
+    (this disambiguates unpadded production output). Otherwise fall back
+    to the spec form (2-digit padded each, length 4).
+    """
+    candidates: list[tuple[int, int]] = []
+    for split in range(1, len(counts)):
+        try:
+            cc = int(counts[:split])
+            ec = int(counts[split:])
+        except ValueError:
+            continue
+        candidates.append((cc, ec))
+
+    # Prefer the candidate whose cipher count matches what we actually saw.
+    for cc, ec in candidates:
+        if cc == observed_cipher_count:
+            return cc, ec
+
+    # Fall back to the spec form (4-char zero-padded) if available.
+    if len(counts) == 4:
+        return int(counts[:2]), int(counts[2:])
+
+    # Last resort: assume single-digit cipher count.
+    if candidates:
+        return candidates[0]
+    raise AssertionError(f"Could not decode JA4_r counts field: {counts!r}")
+
+
+def parse_ja4r(s: str) -> dict:
+    """
+    Parse a JA4_r string into its structural components.
+
+    JA4_r format: t<ver>d<cipher_count><ext_count><ALPN>_<ciphers>_<extensions>_<sigalgs>
+
+    The cipher_count and ext_count fields in the header may be either:
+      - Unpadded (e.g. "128" -- 12 ciphers + 8 extensions, the format
+        currently produced by the production tls.peet.ws server)
+      - Zero-padded to 2 digits each (e.g. "1208" -- 12 + 08, per the JA4
+        spec, the format produced by the local tlsfingerprint.com Docker
+        server)
+
+    Note: the cipher_count and ext_count *header* fields refer to the
+    counts seen on the wire and may include SNI (0x0000) and ALPN (0x0010),
+    while the rendered extension list excludes those. So header counts will
+    NOT always equal `len(extensions)`. This helper returns the header
+    counts as ints (best-effort interpretation, preferring the spec
+    zero-padded form when ambiguous) and the observed list lengths
+    separately.
+
+    Returns a dict with keys:
+      tls_version, alpn, header_cipher_count, header_ext_count,
+      ciphers, extensions, sig_algs, header, raw.
+    """
+    parts = s.split("_")
+    assert len(parts) == 4, f"JA4_r should have 4 underscore-separated parts, got {len(parts)}: {s}"
+
+    header, ciphers_s, exts_s, sigs_s = parts
+    m = _JA4R_HEADER_RE.match(header)
+    assert m, f"JA4_r header malformed: {header!r}"
+
+    ciphers = [c for c in ciphers_s.split(",") if c]
+    extensions = [e for e in exts_s.split(",") if e]
+    sig_algs = [a for a in sigs_s.split(",") if a]
+
+    counts = m.group("counts")
+    header_cc, header_ec = _decode_counts(counts, len(ciphers))
+
+    return {
+        "tls_version": m.group("ver"),
+        "alpn": m.group("alpn"),
+        "header_cipher_count": header_cc,
+        "header_ext_count": header_ec,
+        "ciphers": ciphers,
+        "extensions": extensions,
+        "sig_algs": sig_algs,
+        "header": header,
+        "raw": s,
+    }
+
+
+def assert_ja4r_equivalent(actual: str, expected: str) -> None:
+    """
+    Assert two JA4_r strings are structurally equivalent.
+
+    Header padding for cipher_count/ext_count may differ between servers
+    (production unpadded vs spec-compliant zero-padded), but the body
+    (ciphers, extensions, signature algorithms) and TLS version + ALPN
+    must match exactly.
+    """
+    a = parse_ja4r(actual)
+    e = parse_ja4r(expected)
+    assert a["tls_version"] == e["tls_version"], (
+        f"TLS version mismatch: actual={a['tls_version']} expected={e['tls_version']}"
+    )
+    assert a["alpn"] == e["alpn"], f"ALPN mismatch: actual={a['alpn']} expected={e['alpn']}"
+    assert a["ciphers"] == e["ciphers"], (
+        f"Cipher list mismatch:\nactual:   {a['ciphers']}\nexpected: {e['ciphers']}"
+    )
+    assert a["extensions"] == e["extensions"], (
+        f"Extension list mismatch:\nactual:   {a['extensions']}\nexpected: {e['extensions']}"
+    )
+    assert a["sig_algs"] == e["sig_algs"], (
+        f"Signature algorithm list mismatch:\nactual:   {a['sig_algs']}\nexpected: {e['sig_algs']}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,20 @@
 pytest configuration and shared fixtures for CycleTLS tests.
 """
 
-import pytest
-import sys
 import os
+import sys
 
-# TrackMe base URL — override with TRACKME_URL env var to point at a local instance
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+import pytest
+
+# tlsfingerprint.com base URL — override with TLSFP_URL env var to point at a local instance.
+# Default is the production endpoint (https://tls.peet.ws); CI sets TLSFP_URL to a local Docker
+# container running Danny-Dasilva/tlsfingerprint.com (the source of tls.peet.ws).
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 # Add parent directory to path to import cycletls
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from cycletls import CycleTLS, AsyncCycleTLS
+from cycletls import AsyncCycleTLS, CycleTLS
 
 
 @pytest.fixture(scope="session")
@@ -21,7 +24,7 @@ def cycletls_client():
     Session-scoped CycleTLS client fixture.
     Creates a single client instance for all tests.
 
-    Connection reuse is disabled by default so that TrackMe-style servers
+    Connection reuse is disabled by default so that tlsfingerprint.com-style servers
     (which close connections after every response) don't leave a stale cached
     connection in the global Go transport pool for the next test.
     """
@@ -49,19 +52,19 @@ def cycletls_client_function():
 @pytest.fixture
 def test_url():
     """Base test URL for most tests."""
-    return f"{_TRACKME_URL}/api/clean"
+    return f"{_TLSFP_URL}/api/clean"
 
 
 @pytest.fixture
 def ja3_test_url():
     """TLS fingerprint test URL (replacement for defunct ja3er.com)."""
-    return f"{_TRACKME_URL}/api/clean"
+    return f"{_TLSFP_URL}/api/clean"
 
 
 @pytest.fixture(scope="session")
-def trackme_url():
-    """TrackMe base URL. Set TRACKME_URL env var to point at a local instance."""
-    return _TRACKME_URL
+def tlsfp_url():
+    """tlsfingerprint.com base URL. Set TLSFP_URL env var to point at a local instance."""
+    return _TLSFP_URL
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,16 +25,21 @@ def cycletls_client():
     Session-scoped CycleTLS client fixture.
     Creates a single client instance for all tests.
 
-    Connection reuse is disabled by default so that tlsfingerprint.com-style servers
-    (which close connections after every response) don't leave a stale cached
-    connection in the global Go transport pool for the next test.
+    Connection reuse is disabled ONLY for requests against the local
+    tlsfingerprint.com server (which closes the TLS connection after every
+    response, leaving a stale cached connection in the global Go transport
+    pool for the next test). Requests against httpbin.org and other public
+    endpoints rely on HTTP/1.1 keep-alive working normally; force-disabling
+    reuse there causes "server closed idle connection" / EOF errors on
+    multi-request flows (e.g. cookie set+get, redirect chains).
     """
     client = CycleTLS()
     _orig = client.request
-    def _no_reuse(method, url, **kwargs):
-        kwargs.setdefault("enable_connection_reuse", False)
+    def _no_reuse_for_tlsfp(method, url, **kwargs):
+        if _TLSFP_URL in url:
+            kwargs.setdefault("enable_connection_reuse", False)
         return _orig(method, url, **kwargs)
-    client.request = _no_reuse
+    client.request = _no_reuse_for_tlsfp
     yield client
     client.close()
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,14 +1,17 @@
+import os
 import pytest
 from cycletls import CycleTLS, Request
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 @pytest.fixture
 def simple_request():
     """returns a simple request interface"""
-    return Request(url="https://tls.peet.ws/api/clean", method="get")
+    return Request(url=f"{_TRACKME_URL}/api/clean", method="get")
 
 def test_api_call():
     cycle = CycleTLS()
-    result = cycle.get("https://tls.peet.ws/api/clean")
+    result = cycle.get(f"{_TRACKME_URL}/api/clean")
     
     cycle.close()
     assert result.status_code == 200

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,18 +1,20 @@
 import os
+
 import pytest
+
 from cycletls import CycleTLS, Request
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 @pytest.fixture
 def simple_request():
     """returns a simple request interface"""
-    return Request(url=f"{_TRACKME_URL}/api/clean", method="get")
+    return Request(url=f"{_TLSFP_URL}/api/clean", method="get")
 
 def test_api_call():
     cycle = CycleTLS()
-    result = cycle.get(f"{_TRACKME_URL}/api/clean")
-    
+    result = cycle.get(f"{_TLSFP_URL}/api/clean")
+
     cycle.close()
     assert result.status_code == 200
 

--- a/tests/test_async_ja3.py
+++ b/tests/test_async_ja3.py
@@ -8,9 +8,12 @@ Tests TLS fingerprinting with async requests including:
 - Fingerprint verification
 """
 
+import os
 import pytest
 import cycletls
 from cycletls import AsyncCycleTLS
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 class TestAsyncJA3Fingerprints:
@@ -21,7 +24,7 @@ class TestAsyncJA3Fingerprints:
         """Test async request with Chrome JA3 fingerprint."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
             )
@@ -37,7 +40,7 @@ class TestAsyncJA3Fingerprints:
         """Test async request with Firefox JA3 fingerprint."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0"
             )
@@ -51,7 +54,7 @@ class TestAsyncJA3Fingerprints:
         """Test async request with Safari JA3 fingerprint."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=safari_ja3,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
             )
@@ -64,7 +67,7 @@ class TestAsyncJA3Fingerprints:
     async def test_async_module_function_with_ja3(self, chrome_ja3):
         """Test module-level async function with JA3."""
         response = await cycletls.aget(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
         )
@@ -85,19 +88,19 @@ class TestAsyncConcurrentJA3:
         # Different JA3 fingerprints require separate connections
         tasks = [
             cycletls.aget(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
             ),
             cycletls.aget(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 enable_connection_reuse=False,
             ),
             cycletls.aget(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=safari_ja3,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
                 enable_connection_reuse=False,
@@ -123,7 +126,7 @@ class TestAsyncConcurrentJA3:
         # Same JA3 fingerprint - connection reuse should work but disable for test isolation
         tasks = [
             cycletls.aget(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -148,7 +151,7 @@ class TestAsyncJA4Fingerprints:
             ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,4469_0403,0804,0401,0503,0805,0501,0806,0601"
 
             response = await client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja4r=ja4r,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
             )
@@ -161,7 +164,7 @@ class TestAsyncJA4Fingerprints:
         ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,4469_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = await cycletls.aget(
-            "https://tls.peet.ws/api/all",
+            f"{_TRACKME_URL}/api/all",
             ja4r=ja4r,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
             enable_connection_reuse=False,
@@ -222,7 +225,7 @@ class TestAsyncBrowserProfiles:
         """Test async request with complete Chrome profile."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                 headers={
@@ -248,7 +251,7 @@ class TestAsyncBrowserProfiles:
         """Test async request with complete Firefox profile."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 headers={
@@ -276,14 +279,14 @@ class TestAsyncFingerprintPersistence:
         async with AsyncCycleTLS() as client:
             # Multiple requests with same fingerprint - connection reuse disabled for test isolation
             response1 = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
             )
 
             response2 = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -298,7 +301,7 @@ class TestAsyncFingerprintPersistence:
         async with AsyncCycleTLS() as client:
             # Request with Chrome fingerprint - switching fingerprints requires new connections
             response1 = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -306,7 +309,7 @@ class TestAsyncFingerprintPersistence:
 
             # Switch to Firefox fingerprint
             response2 = await client.get(
-                "https://tls.peet.ws/api/clean",
+                f"{_TRACKME_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 enable_connection_reuse=False,

--- a/tests/test_async_ja3.py
+++ b/tests/test_async_ja3.py
@@ -28,7 +28,8 @@ class TestAsyncJA3Fingerprints:
             response = await client.get(
                 f"{_TRACKME_URL}/api/clean",
                 ja3=chrome_ja3,
-                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                enable_connection_reuse=False,
             )
 
             assert response.status_code == 200
@@ -44,7 +45,8 @@ class TestAsyncJA3Fingerprints:
             response = await client.get(
                 f"{_TRACKME_URL}/api/clean",
                 ja3=firefox_ja3,
-                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0"
+                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
+                enable_connection_reuse=False,
             )
 
             assert response.status_code == 200
@@ -58,7 +60,8 @@ class TestAsyncJA3Fingerprints:
             response = await client.get(
                 f"{_TRACKME_URL}/api/clean",
                 ja3=safari_ja3,
-                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+                enable_connection_reuse=False,
             )
 
             assert response.status_code == 200
@@ -71,7 +74,8 @@ class TestAsyncJA3Fingerprints:
         response = await cycletls.aget(
             f"{_TRACKME_URL}/api/clean",
             ja3=chrome_ja3,
-            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            enable_connection_reuse=False,
         )
 
         assert response.status_code == 200
@@ -155,7 +159,8 @@ class TestAsyncJA4Fingerprints:
             response = await client.get(
                 f"{_TRACKME_URL}/api/all",
                 ja4r=ja4r,
-                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+                enable_connection_reuse=False,
             )
 
             assert response.status_code == 200

--- a/tests/test_async_ja3.py
+++ b/tests/test_async_ja3.py
@@ -15,6 +15,8 @@ from cycletls import AsyncCycleTLS
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 class TestAsyncJA3Fingerprints:
     """Test async requests with JA3 fingerprints."""

--- a/tests/test_async_ja3.py
+++ b/tests/test_async_ja3.py
@@ -9,11 +9,13 @@ Tests TLS fingerprinting with async requests including:
 """
 
 import os
+
 import pytest
+
 import cycletls
 from cycletls import AsyncCycleTLS
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -26,7 +28,7 @@ class TestAsyncJA3Fingerprints:
         """Test async request with Chrome JA3 fingerprint."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                 enable_connection_reuse=False,
@@ -43,7 +45,7 @@ class TestAsyncJA3Fingerprints:
         """Test async request with Firefox JA3 fingerprint."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 enable_connection_reuse=False,
@@ -58,7 +60,7 @@ class TestAsyncJA3Fingerprints:
         """Test async request with Safari JA3 fingerprint."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=safari_ja3,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
                 enable_connection_reuse=False,
@@ -72,7 +74,7 @@ class TestAsyncJA3Fingerprints:
     async def test_async_module_function_with_ja3(self, chrome_ja3):
         """Test module-level async function with JA3."""
         response = await cycletls.aget(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
             enable_connection_reuse=False,
@@ -94,19 +96,19 @@ class TestAsyncConcurrentJA3:
         # Different JA3 fingerprints require separate connections
         tasks = [
             cycletls.aget(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
             ),
             cycletls.aget(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 enable_connection_reuse=False,
             ),
             cycletls.aget(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=safari_ja3,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
                 enable_connection_reuse=False,
@@ -132,7 +134,7 @@ class TestAsyncConcurrentJA3:
         # Same JA3 fingerprint - connection reuse should work but disable for test isolation
         tasks = [
             cycletls.aget(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -157,7 +159,7 @@ class TestAsyncJA4Fingerprints:
             ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,4469_0403,0804,0401,0503,0805,0501,0806,0601"
 
             response = await client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja4r=ja4r,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -171,7 +173,7 @@ class TestAsyncJA4Fingerprints:
         ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,4469_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = await cycletls.aget(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=ja4r,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
             enable_connection_reuse=False,
@@ -232,7 +234,7 @@ class TestAsyncBrowserProfiles:
         """Test async request with complete Chrome profile."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                 headers={
@@ -258,7 +260,7 @@ class TestAsyncBrowserProfiles:
         """Test async request with complete Firefox profile."""
         async with AsyncCycleTLS() as client:
             response = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 headers={
@@ -286,14 +288,14 @@ class TestAsyncFingerprintPersistence:
         async with AsyncCycleTLS() as client:
             # Multiple requests with same fingerprint - connection reuse disabled for test isolation
             response1 = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
             )
 
             response2 = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -308,7 +310,7 @@ class TestAsyncFingerprintPersistence:
         async with AsyncCycleTLS() as client:
             # Request with Chrome fingerprint - switching fingerprints requires new connections
             response1 = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=chrome_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 enable_connection_reuse=False,
@@ -316,7 +318,7 @@ class TestAsyncFingerprintPersistence:
 
             # Switch to Firefox fingerprint
             response2 = await client.get(
-                f"{_TRACKME_URL}/api/clean",
+                f"{_TLSFP_URL}/api/clean",
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
                 enable_connection_reuse=False,

--- a/tests/test_force_http1.py
+++ b/tests/test_force_http1.py
@@ -3,8 +3,11 @@ Tests for force_http1 functionality.
 Based on CycleTLS/tests/forceHTTP1.test.ts
 """
 
+import os
 import pytest
 from cycletls import CycleTLS
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 @pytest.fixture
@@ -29,7 +32,7 @@ def chrome_user_agent():
 
 def test_http2_by_default(client, chrome_ja3, chrome_user_agent):
     """Test that HTTP/2 is used by default when server supports it"""
-    url = "https://tls.peet.ws/api/all"
+    url = f"{_TRACKME_URL}/api/all"
 
     result = client.get(
         url,
@@ -48,7 +51,7 @@ def test_http2_by_default(client, chrome_ja3, chrome_user_agent):
 
 def test_force_http1_on_http2_server(client, chrome_ja3, chrome_user_agent):
     """Test that HTTP/1.1 is forced when force_http1 is True"""
-    url = "https://tls.peet.ws/api/all"
+    url = f"{_TRACKME_URL}/api/all"
 
     result = client.get(
         url,

--- a/tests/test_force_http1.py
+++ b/tests/test_force_http1.py
@@ -14,8 +14,13 @@ pytestmark = pytest.mark.live
 
 @pytest.fixture
 def client():
-    """Create a CycleTLS client instance"""
+    """Create a CycleTLS client instance with connection reuse disabled."""
     cycle = CycleTLS()
+    _orig = cycle.request
+    def _no_reuse(method, url, **kwargs):
+        kwargs.setdefault("enable_connection_reuse", False)
+        return _orig(method, url, **kwargs)
+    cycle.request = _no_reuse
     yield cycle
     cycle.close()
 

--- a/tests/test_force_http1.py
+++ b/tests/test_force_http1.py
@@ -9,6 +9,8 @@ from cycletls import CycleTLS
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 @pytest.fixture
 def client():

--- a/tests/test_force_http1.py
+++ b/tests/test_force_http1.py
@@ -16,13 +16,22 @@ pytestmark = pytest.mark.live
 
 @pytest.fixture
 def client():
-    """Create a CycleTLS client instance with connection reuse disabled."""
+    """Create a CycleTLS client instance.
+
+    Connection reuse is disabled ONLY for requests against the local
+    tlsfingerprint.com server (which closes the TLS connection after each
+    response). Requests against httpbin.org rely on HTTP/1.1 keep-alive
+    and break when reuse is force-disabled (httpbin closes idle conns
+    aggressively, causing "server closed idle connection" / EOF errors
+    on the next request).
+    """
     cycle = CycleTLS()
     _orig = cycle.request
-    def _no_reuse(method, url, **kwargs):
-        kwargs.setdefault("enable_connection_reuse", False)
+    def _no_reuse_for_tlsfp(method, url, **kwargs):
+        if _TLSFP_URL in url:
+            kwargs.setdefault("enable_connection_reuse", False)
         return _orig(method, url, **kwargs)
-    cycle.request = _no_reuse
+    cycle.request = _no_reuse_for_tlsfp
     yield cycle
     cycle.close()
 

--- a/tests/test_force_http1.py
+++ b/tests/test_force_http1.py
@@ -4,10 +4,12 @@ Based on CycleTLS/tests/forceHTTP1.test.ts
 """
 
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -39,7 +41,7 @@ def chrome_user_agent():
 
 def test_http2_by_default(client, chrome_ja3, chrome_user_agent):
     """Test that HTTP/2 is used by default when server supports it"""
-    url = f"{_TRACKME_URL}/api/all"
+    url = f"{_TLSFP_URL}/api/all"
 
     result = client.get(
         url,
@@ -58,7 +60,7 @@ def test_http2_by_default(client, chrome_ja3, chrome_user_agent):
 
 def test_force_http1_on_http2_server(client, chrome_ja3, chrome_user_agent):
     """Test that HTTP/1.1 is forced when force_http1 is True"""
-    url = f"{_TRACKME_URL}/api/all"
+    url = f"{_TLSFP_URL}/api/all"
 
     result = client.get(
         url,

--- a/tests/test_frame_headers.py
+++ b/tests/test_frame_headers.py
@@ -18,6 +18,8 @@ from cycletls import CycleTLS
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 class TestChromeFrameHeaders:
     """Test Chrome browser HTTP/2 frame headers."""

--- a/tests/test_frame_headers.py
+++ b/tests/test_frame_headers.py
@@ -12,8 +12,11 @@ Note: Most tests are marked as skipped if frame details are not exposed
 in the Python API. This functionality may be internal to the Go backend.
 """
 
+import os
 import pytest
 from cycletls import CycleTLS
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 class TestChromeFrameHeaders:
@@ -29,7 +32,7 @@ class TestChromeFrameHeaders:
 
         try:
             response = client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=chrome_ja3,
                 user_agent=chrome_ua
             )
@@ -95,7 +98,7 @@ class TestChromeFrameHeaders:
 
         try:
             response = client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=chrome_ja3
             )
 
@@ -135,7 +138,7 @@ class TestFirefoxFrameHeaders:
 
         try:
             response = client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=firefox_ja3,
                 user_agent=firefox_ua
             )
@@ -196,12 +199,12 @@ class TestFirefoxFrameHeaders:
 
         try:
             chrome_response = chrome_client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=chrome_ja3
             )
 
             firefox_response = firefox_client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=firefox_ja3
             )
 
@@ -247,7 +250,7 @@ class TestFrameTypes:
 
         try:
             response = client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 force_http1=False  # Ensure HTTP/2
             )
 
@@ -275,7 +278,7 @@ class TestFrameTypes:
         client = CycleTLS()
 
         try:
-            response = client.get("https://tls.peet.ws/api/all")
+            response = client.get(f"{_TRACKME_URL}/api/all")
 
             data = response.json()
 
@@ -301,7 +304,7 @@ class TestFrameTypes:
         client = CycleTLS()
 
         try:
-            response = client.get("https://tls.peet.ws/api/all")
+            response = client.get(f"{_TRACKME_URL}/api/all")
 
             data = response.json()
 
@@ -402,7 +405,7 @@ class TestHTTP2Fingerprinting:
         client = CycleTLS()
 
         try:
-            response = client.get("https://tls.peet.ws/api/all")
+            response = client.get(f"{_TRACKME_URL}/api/all")
 
             data = response.json()
 
@@ -429,7 +432,7 @@ class TestBrowserSpecificFingerprints:
 
         try:
             response = client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=chrome_ja3
             )
 
@@ -461,7 +464,7 @@ class TestBrowserSpecificFingerprints:
 
         try:
             response = client.get(
-                "https://tls.peet.ws/api/all",
+                f"{_TRACKME_URL}/api/all",
                 ja3=firefox_ja3
             )
 

--- a/tests/test_frame_headers.py
+++ b/tests/test_frame_headers.py
@@ -13,10 +13,12 @@ in the Python API. This functionality may be internal to the Go backend.
 """
 
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -34,7 +36,7 @@ class TestChromeFrameHeaders:
 
         try:
             response = client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=chrome_ja3,
                 user_agent=chrome_ua
             )
@@ -100,7 +102,7 @@ class TestChromeFrameHeaders:
 
         try:
             response = client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=chrome_ja3
             )
 
@@ -140,7 +142,7 @@ class TestFirefoxFrameHeaders:
 
         try:
             response = client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=firefox_ja3,
                 user_agent=firefox_ua
             )
@@ -201,12 +203,12 @@ class TestFirefoxFrameHeaders:
 
         try:
             chrome_response = chrome_client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=chrome_ja3
             )
 
             firefox_response = firefox_client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=firefox_ja3
             )
 
@@ -252,7 +254,7 @@ class TestFrameTypes:
 
         try:
             response = client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 force_http1=False  # Ensure HTTP/2
             )
 
@@ -280,7 +282,7 @@ class TestFrameTypes:
         client = CycleTLS()
 
         try:
-            response = client.get(f"{_TRACKME_URL}/api/all")
+            response = client.get(f"{_TLSFP_URL}/api/all")
 
             data = response.json()
 
@@ -306,7 +308,7 @@ class TestFrameTypes:
         client = CycleTLS()
 
         try:
-            response = client.get(f"{_TRACKME_URL}/api/all")
+            response = client.get(f"{_TLSFP_URL}/api/all")
 
             data = response.json()
 
@@ -407,7 +409,7 @@ class TestHTTP2Fingerprinting:
         client = CycleTLS()
 
         try:
-            response = client.get(f"{_TRACKME_URL}/api/all")
+            response = client.get(f"{_TLSFP_URL}/api/all")
 
             data = response.json()
 
@@ -434,7 +436,7 @@ class TestBrowserSpecificFingerprints:
 
         try:
             response = client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=chrome_ja3
             )
 
@@ -466,7 +468,7 @@ class TestBrowserSpecificFingerprints:
 
         try:
             response = client.get(
-                f"{_TRACKME_URL}/api/all",
+                f"{_TLSFP_URL}/api/all",
                 ja3=firefox_ja3
             )
 

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -9,8 +9,13 @@ pytestmark = pytest.mark.live
 
 @pytest.fixture
 def cycle():
-    """Create a CycleTLS instance for testing"""
+    """Create a CycleTLS instance for testing with connection reuse disabled."""
     with CycleTLS() as client:
+        _orig = client.request
+        def _no_reuse(method, url, **kwargs):
+            kwargs.setdefault("enable_connection_reuse", False)
+            return _orig(method, url, **kwargs)
+        client.request = _no_reuse
         yield client
 
 

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -4,6 +4,8 @@ from cycletls import CycleTLS
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 @pytest.fixture
 def cycle():

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -1,5 +1,8 @@
+import os
 import pytest
 from cycletls import CycleTLS
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 @pytest.fixture
@@ -30,7 +33,7 @@ class TestHTTP2:
         # Use tls.peet.ws as it's more reliable than ja3er.com
         # Test HTTP/2 (default)
         response_http2 = cycle.get(
-            "https://tls.peet.ws/api/all",
+            f"{_TRACKME_URL}/api/all",
             force_http1=False,
             ja3="771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21,29-23-24,0",
             timeout=30
@@ -38,7 +41,7 @@ class TestHTTP2:
 
         # Test HTTP/1.1 (forced)
         response_http1 = cycle.get(
-            "https://tls.peet.ws/api/all",
+            f"{_TRACKME_URL}/api/all",
             force_http1=True,
             ja3="771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21,29-23-24,0",
             timeout=30

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -1,8 +1,10 @@
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -40,7 +42,7 @@ class TestHTTP2:
         # Use tls.peet.ws as it's more reliable than ja3er.com
         # Test HTTP/2 (default)
         response_http2 = cycle.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             force_http1=False,
             ja3="771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21,29-23-24,0",
             timeout=30
@@ -48,7 +50,7 @@ class TestHTTP2:
 
         # Test HTTP/1.1 (forced)
         response_http1 = cycle.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             force_http1=True,
             ja3="771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21,29-23-24,0",
             timeout=30

--- a/tests/test_http2_fingerprint.py
+++ b/tests/test_http2_fingerprint.py
@@ -12,9 +12,12 @@ HTTP/2 fingerprints allow customization of HTTP/2 connection settings to mimic
 different browsers and avoid detection.
 """
 
+import os
 import pytest
 import json
 from test_utils import assert_valid_response, assert_valid_json_response
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 class TestHTTP2FingerprintBasic:
@@ -27,7 +30,7 @@ class TestHTTP2FingerprintBasic:
         firefox_http2 = "1:65536;2:0;4:131072;5:16384|12517377|0|m,p,a,s"
 
         response = cycletls_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             http2_fingerprint=firefox_http2,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0',
             timeout=30
@@ -60,7 +63,7 @@ class TestHTTP2FingerprintBasic:
         chrome_http2 = "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p"
 
         response = cycletls_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             http2_fingerprint=chrome_http2,
             user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
             timeout=30

--- a/tests/test_http2_fingerprint.py
+++ b/tests/test_http2_fingerprint.py
@@ -19,6 +19,8 @@ from test_utils import assert_valid_response, assert_valid_json_response
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 class TestHTTP2FingerprintBasic:
     """Test basic HTTP/2 fingerprinting functionality."""

--- a/tests/test_http2_fingerprint.py
+++ b/tests/test_http2_fingerprint.py
@@ -12,12 +12,13 @@ HTTP/2 fingerprints allow customization of HTTP/2 connection settings to mimic
 different browsers and avoid detection.
 """
 
-import os
-import pytest
 import json
-from test_utils import assert_valid_response, assert_valid_json_response
+import os
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+import pytest
+from test_utils import assert_valid_response
+
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -32,7 +33,7 @@ class TestHTTP2FingerprintBasic:
         firefox_http2 = "1:65536;2:0;4:131072;5:16384|12517377|0|m,p,a,s"
 
         response = cycletls_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             http2_fingerprint=firefox_http2,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0',
             timeout=30
@@ -65,7 +66,7 @@ class TestHTTP2FingerprintBasic:
         chrome_http2 = "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p"
 
         response = cycletls_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             http2_fingerprint=chrome_http2,
             user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
             timeout=30

--- a/tests/test_http2_fingerprint_tlsfingerprint.py
+++ b/tests/test_http2_fingerprint_tlsfingerprint.py
@@ -1,27 +1,28 @@
 """
-HTTP/2 Fingerprint Validation Tests against tlsfingerprint.com
+HTTP/2 Fingerprint Validation Tests against tls.peet.ws
 
 Tests HTTP/2 Akamai fingerprint generation and validation by verifying the
-observed fingerprints at tlsfingerprint.com.
+observed fingerprints at tls.peet.ws.
 
 Run with: pytest tests/test_http2_fingerprint_tlsfingerprint.py -v -m live
 Skip with: pytest -m "not live"
 
 Based on: test_http2_fingerprint.py, test_frame_headers.py
 """
+import os
 import pytest
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL for tlsfingerprint.com
-BASE_URL = "https://tlsfingerprint.com"
+# Base URL — override with TRACKME_URL to point at a local TrackMe instance
+BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 def extract_http2_from_response(data: dict) -> dict:
     """
-    Extract HTTP/2 fingerprint data from tlsfingerprint.com response.
+    Extract HTTP/2 fingerprint data from tls.peet.ws response.
 
     Response format:
     {
@@ -48,7 +49,7 @@ class TestHTTP2FingerprintData:
     """Test that HTTP/2 fingerprint data is returned"""
 
     def test_response_contains_http2_data(self, cycle_client):
-        """Test that tlsfingerprint.com returns HTTP/2 data"""
+        """Test that tls.peet.ws returns HTTP/2 data"""
         response = cycle_client.get(f"{BASE_URL}/api/all")
 
         assert response.status_code == 200

--- a/tests/test_http2_fingerprint_tlsfingerprint.py
+++ b/tests/test_http2_fingerprint_tlsfingerprint.py
@@ -40,8 +40,20 @@ def extract_http2_from_response(data: dict) -> dict:
 
 @pytest.fixture(scope="function")
 def cycle_client():
-    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
+    """Create a CycleTLS client with connection reuse disabled.
+
+    TrackMe closes connections after each request. With the default
+    enable_connection_reuse=True the Go transport caches the TLS connection
+    globally; the next test picks up the closed connection and gets
+    "use of closed network connection". Setting enable_connection_reuse=False
+    creates a fresh roundTripper per request, avoiding stale connections.
+    """
     with CycleTLS() as client:
+        _orig_request = client.request
+        def _no_reuse(method, url, **kwargs):
+            kwargs.setdefault("enable_connection_reuse", False)
+            return _orig_request(method, url, **kwargs)
+        client.request = _no_reuse
         yield client
 
 

--- a/tests/test_http2_fingerprint_tlsfingerprint.py
+++ b/tests/test_http2_fingerprint_tlsfingerprint.py
@@ -38,9 +38,9 @@ def extract_http2_from_response(data: dict) -> dict:
     return data.get("http2", {})
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def cycle_client():
-    """Create a single CycleTLS client for all tests in this module"""
+    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
     with CycleTLS() as client:
         yield client
 

--- a/tests/test_http2_fingerprint_tlsfingerprint.py
+++ b/tests/test_http2_fingerprint_tlsfingerprint.py
@@ -10,14 +10,16 @@ Skip with: pytest -m "not live"
 Based on: test_http2_fingerprint.py, test_frame_headers.py
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL — override with TRACKME_URL to point at a local TrackMe instance
-BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+# Base URL — override with TLSFP_URL to point at a local tlsfingerprint.com Docker instance
+BASE_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 
 def extract_http2_from_response(data: dict) -> dict:
@@ -42,7 +44,7 @@ def extract_http2_from_response(data: dict) -> dict:
 def cycle_client():
     """Create a CycleTLS client with connection reuse disabled.
 
-    TrackMe closes connections after each request. With the default
+    tlsfingerprint.com closes connections after each request. With the default
     enable_connection_reuse=True the Go transport caches the TLS connection
     globally; the next test picks up the closed connection and gets
     "use of closed network connection". Setting enable_connection_reuse=False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,6 +25,8 @@ from test_utils import (
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 class TestBasicRequests:
     """Test basic HTTP GET requests."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,7 @@ Based on CycleTLS TypeScript integration tests, these tests verify:
 All tests use httpbin.org or ja3er.com as test endpoints.
 """
 
+import os
 import pytest
 import json
 from test_utils import (
@@ -21,6 +22,8 @@ from test_utils import (
     assert_valid_json_response,
     extract_json_field,
 )
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 class TestBasicRequests:
@@ -38,7 +41,7 @@ class TestBasicRequests:
     def test_get_with_ja3er(self, cycletls_client):
         """Test GET request to TLS fingerprint service to verify JA3 fingerprinting."""
         # Use tls.peet.ws instead of ja3er.com which is unreliable
-        response = cycletls_client.get("https://tls.peet.ws/api/clean", timeout=30)
+        response = cycletls_client.get(f"{_TRACKME_URL}/api/clean", timeout=30)
         assert_valid_response(response, expected_status=200)
 
         # Verify JA3 data is present
@@ -92,7 +95,7 @@ class TestUserAgent:
 
         # Use tls.peet.ws instead of ja3er.com which is unreliable
         response = cycletls_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             user_agent=custom_ua,
             ja3=firefox_ja3,
             timeout=30

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,16 +14,16 @@ Based on CycleTLS TypeScript integration tests, these tests verify:
 All tests use httpbin.org or ja3er.com as test endpoints.
 """
 
-import os
-import pytest
 import json
+import os
+
+import pytest
 from test_utils import (
-    assert_valid_response,
     assert_valid_json_response,
-    extract_json_field,
+    assert_valid_response,
 )
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -43,7 +43,7 @@ class TestBasicRequests:
     def test_get_with_ja3er(self, cycletls_client):
         """Test GET request to TLS fingerprint service to verify JA3 fingerprinting."""
         # Use tls.peet.ws instead of ja3er.com which is unreliable
-        response = cycletls_client.get(f"{_TRACKME_URL}/api/clean", timeout=30)
+        response = cycletls_client.get(f"{_TLSFP_URL}/api/clean", timeout=30)
         assert_valid_response(response, expected_status=200)
 
         # Verify JA3 data is present
@@ -97,7 +97,7 @@ class TestUserAgent:
 
         # Use tls.peet.ws instead of ja3er.com which is unreliable
         response = cycletls_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             user_agent=custom_ua,
             ja3=firefox_ja3,
             timeout=30

--- a/tests/test_integration_tlsfingerprint.py
+++ b/tests/test_integration_tlsfingerprint.py
@@ -22,8 +22,20 @@ BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 @pytest.fixture(scope="function")
 def cycle_client():
-    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
+    """Create a CycleTLS client with connection reuse disabled.
+
+    TrackMe closes connections after each request. With the default
+    enable_connection_reuse=True the Go transport caches the TLS connection
+    globally; the next test picks up the closed connection and gets
+    "use of closed network connection". Setting enable_connection_reuse=False
+    creates a fresh roundTripper per request, avoiding stale connections.
+    """
     with CycleTLS() as client:
+        _orig_request = client.request
+        def _no_reuse(method, url, **kwargs):
+            kwargs.setdefault("enable_connection_reuse", False)
+            return _orig_request(method, url, **kwargs)
+        client.request = _no_reuse
         yield client
 
 

--- a/tests/test_integration_tlsfingerprint.py
+++ b/tests/test_integration_tlsfingerprint.py
@@ -1,22 +1,23 @@
 """
-Integration Tests against tlsfingerprint.com
+Integration Tests against tls.peet.ws
 
 Tests HTTP methods, headers, response parsing, and other integration
-functionality against the live tlsfingerprint.com service.
+functionality against the live tls.peet.ws service.
 
 Run with: pytest tests/test_integration_tlsfingerprint.py -v -m live
 Skip with: pytest -m "not live"
 
 Based on: test_integration.py
 """
+import os
 import pytest
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL for tlsfingerprint.com
-BASE_URL = "https://tlsfingerprint.com"
+# Base URL — override with TRACKME_URL to point at a local TrackMe instance
+BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 @pytest.fixture(scope="module")
@@ -244,7 +245,7 @@ class TestClientArchitecture:
 
 
 class TestAPIEndpoints:
-    """Test all tlsfingerprint.com API endpoints"""
+    """Test all tls.peet.ws API endpoints"""
 
     def test_api_all(self, cycle_client):
         """Test /api/all endpoint returns comprehensive data"""
@@ -279,7 +280,7 @@ class TestAPIEndpoints:
 
 
 class TestResponseMetadata:
-    """Test response metadata from tlsfingerprint.com"""
+    """Test response metadata from tls.peet.ws"""
 
     def test_ip_returned(self, cycle_client):
         """Test that client IP is returned"""

--- a/tests/test_integration_tlsfingerprint.py
+++ b/tests/test_integration_tlsfingerprint.py
@@ -12,6 +12,7 @@ Based on: test_integration.py
 import os
 import pytest
 from cycletls import CycleTLS
+from cycletls.exceptions import Timeout as CycleTLSTimeout
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
@@ -79,14 +80,18 @@ class TestHTTPMethods:
 
     def test_post_method(self, cycle_client):
         """Test POST request method"""
-        response = cycle_client.post(
-            f"{BASE_URL}/api/all",
-            data='{"test": "data"}'
-        )
-
-        # POST may return 200 or 405 depending on endpoint support
-        assert response.status_code in [200, 405], \
-            f"POST should return 200 or 405, got {response.status_code}"
+        try:
+            response = cycle_client.post(
+                f"{BASE_URL}/api/all",
+                data='{"test": "data"}'
+            )
+            # POST may return 200 or 405 depending on endpoint support
+            assert response.status_code in [200, 405], \
+                f"POST should return 200 or 405, got {response.status_code}"
+        except CycleTLSTimeout:
+            # Local TrackMe rejects non-GET methods via HTTP/2 RST_STREAM,
+            # causing the Go client to time out. Treat this as acceptable.
+            pytest.skip("TrackMe does not support POST (HTTP/2 RST_STREAM)")
 
     def test_head_method(self, cycle_client):
         """Test HEAD request method"""
@@ -249,8 +254,8 @@ class TestClientArchitecture:
     def test_multiple_clients(self):
         """Test multiple client instances"""
         with CycleTLS() as client1, CycleTLS() as client2:
-            response1 = client1.get(f"{BASE_URL}/api/clean")
-            response2 = client2.get(f"{BASE_URL}/api/clean")
+            response1 = client1.get(f"{BASE_URL}/api/clean", enable_connection_reuse=False)
+            response2 = client2.get(f"{BASE_URL}/api/clean", enable_connection_reuse=False)
 
             assert response1.status_code == 200
             assert response2.status_code == 200

--- a/tests/test_integration_tlsfingerprint.py
+++ b/tests/test_integration_tlsfingerprint.py
@@ -20,9 +20,9 @@ pytestmark = pytest.mark.live
 BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def cycle_client():
-    """Create a single CycleTLS client for all tests in this module"""
+    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
     with CycleTLS() as client:
         yield client
 

--- a/tests/test_integration_tlsfingerprint.py
+++ b/tests/test_integration_tlsfingerprint.py
@@ -10,22 +10,24 @@ Skip with: pytest -m "not live"
 Based on: test_integration.py
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 from cycletls.exceptions import Timeout as CycleTLSTimeout
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL — override with TRACKME_URL to point at a local TrackMe instance
-BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+# Base URL — override with TLSFP_URL to point at a local tlsfingerprint.com Docker instance
+BASE_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 
 @pytest.fixture(scope="function")
 def cycle_client():
     """Create a CycleTLS client with connection reuse disabled.
 
-    TrackMe closes connections after each request. With the default
+    tlsfingerprint.com closes connections after each request. With the default
     enable_connection_reuse=True the Go transport caches the TLS connection
     globally; the next test picks up the closed connection and gets
     "use of closed network connection". Setting enable_connection_reuse=False
@@ -89,9 +91,9 @@ class TestHTTPMethods:
             assert response.status_code in [200, 405], \
                 f"POST should return 200 or 405, got {response.status_code}"
         except CycleTLSTimeout:
-            # Local TrackMe rejects non-GET methods via HTTP/2 RST_STREAM,
+            # Local tlsfingerprint.com rejects non-GET methods via HTTP/2 RST_STREAM,
             # causing the Go client to time out. Treat this as acceptable.
-            pytest.skip("TrackMe does not support POST (HTTP/2 RST_STREAM)")
+            pytest.skip("tlsfingerprint.com server does not support POST (HTTP/2 RST_STREAM)")
 
     def test_head_method(self, cycle_client):
         """Test HEAD request method"""

--- a/tests/test_ja3_fingerprints.py
+++ b/tests/test_ja3_fingerprints.py
@@ -12,6 +12,8 @@ from cycletls import CycleTLS
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 # Test data structure matching the Go implementation
 JA3_FINGERPRINTS = [

--- a/tests/test_ja3_fingerprints.py
+++ b/tests/test_ja3_fingerprints.py
@@ -113,8 +113,13 @@ JA3_FINGERPRINTS = [
 
 @pytest.fixture(scope="module")
 def cycle_client():
-    """Create a single CycleTLS client for all tests in this module"""
+    """Create a single CycleTLS client for all tests in this module with connection reuse disabled."""
     client = CycleTLS()
+    _orig = client.request
+    def _no_reuse(method, url, **kwargs):
+        kwargs.setdefault("enable_connection_reuse", False)
+        return _orig(method, url, **kwargs)
+    client.request = _no_reuse
     yield client
     client.close()
 

--- a/tests/test_ja3_fingerprints.py
+++ b/tests/test_ja3_fingerprints.py
@@ -6,8 +6,11 @@ that CycleTLS correctly implements TLS fingerprinting for different browsers.
 
 Based on: /Users/dannydasilva/Documents/personal/CycleTLS/cycletls/tests/integration/main_ja3_test.go
 """
+import os
 import pytest
 from cycletls import CycleTLS
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 # Test data structure matching the Go implementation
@@ -126,7 +129,7 @@ class TestJA3Fingerprints:
         match the expected values for each browser fingerprint.
         """
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,  # Different JA3 fingerprints require new connections
@@ -154,7 +157,7 @@ class TestChromeFingerprints:
         """Test Chrome 58 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 58")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -168,7 +171,7 @@ class TestChromeFingerprints:
         """Test Chrome 62 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 62")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -182,7 +185,7 @@ class TestChromeFingerprints:
         """Test Chrome 70 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 70")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -196,7 +199,7 @@ class TestChromeFingerprints:
         """Test Chrome 72 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 72")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -210,7 +213,7 @@ class TestChromeFingerprints:
         """Test Chrome 83 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 83")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -228,7 +231,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 55 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 55")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -242,7 +245,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 56 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 56")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -256,7 +259,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 63 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 63")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -270,7 +273,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 65 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 65")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -288,7 +291,7 @@ class TestSafariFingerprints:
         """Test iOS 11 Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "iOS 11 Safari")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -302,7 +305,7 @@ class TestSafariFingerprints:
         """Test iOS 12 Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "iOS 12 Safari")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -316,7 +319,7 @@ class TestSafariFingerprints:
         """Test iOS 17 Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "iOS 17 Safari")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -330,7 +333,7 @@ class TestSafariFingerprints:
         """Test macOS Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "macOS Safari")
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -349,7 +352,7 @@ class TestJA3StringValidation:
         # Test with a known good fingerprint
         fingerprint = JA3_FINGERPRINTS[0]
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -369,7 +372,7 @@ class TestJA3StringValidation:
         expected_hash = "b32309a26951912be7dba376398abc3b"
 
         response = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=custom_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36",
             enable_connection_reuse=False,
@@ -386,14 +389,14 @@ class TestJA3StringValidation:
 
         # Make two requests with the same JA3 - here connection reuse is OK since same fingerprint
         response1 = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,  # Still disable for test isolation
         )
 
         response2 = cycle_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,

--- a/tests/test_ja3_fingerprints.py
+++ b/tests/test_ja3_fingerprints.py
@@ -7,10 +7,12 @@ that CycleTLS correctly implements TLS fingerprinting for different browsers.
 Based on: /Users/dannydasilva/Documents/personal/CycleTLS/cycletls/tests/integration/main_ja3_test.go
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -136,7 +138,7 @@ class TestJA3Fingerprints:
         match the expected values for each browser fingerprint.
         """
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,  # Different JA3 fingerprints require new connections
@@ -164,7 +166,7 @@ class TestChromeFingerprints:
         """Test Chrome 58 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 58")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -178,7 +180,7 @@ class TestChromeFingerprints:
         """Test Chrome 62 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 62")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -192,7 +194,7 @@ class TestChromeFingerprints:
         """Test Chrome 70 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 70")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -206,7 +208,7 @@ class TestChromeFingerprints:
         """Test Chrome 72 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 72")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -220,7 +222,7 @@ class TestChromeFingerprints:
         """Test Chrome 83 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Chrome 83")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -238,7 +240,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 55 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 55")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -252,7 +254,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 56 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 56")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -266,7 +268,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 63 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 63")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -280,7 +282,7 @@ class TestFirefoxFingerprints:
         """Test Firefox 65 fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "Firefox 65")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -298,7 +300,7 @@ class TestSafariFingerprints:
         """Test iOS 11 Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "iOS 11 Safari")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -312,7 +314,7 @@ class TestSafariFingerprints:
         """Test iOS 12 Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "iOS 12 Safari")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -326,7 +328,7 @@ class TestSafariFingerprints:
         """Test iOS 17 Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "iOS 17 Safari")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -340,7 +342,7 @@ class TestSafariFingerprints:
         """Test macOS Safari fingerprint"""
         fingerprint = next(fp for fp in JA3_FINGERPRINTS if fp["name"] == "macOS Safari")
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -359,7 +361,7 @@ class TestJA3StringValidation:
         # Test with a known good fingerprint
         fingerprint = JA3_FINGERPRINTS[0]
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,
@@ -379,7 +381,7 @@ class TestJA3StringValidation:
         expected_hash = "b32309a26951912be7dba376398abc3b"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=custom_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36",
             enable_connection_reuse=False,
@@ -396,14 +398,14 @@ class TestJA3StringValidation:
 
         # Make two requests with the same JA3 - here connection reuse is OK since same fingerprint
         response1 = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,  # Still disable for test isolation
         )
 
         response2 = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=fingerprint["ja3"],
             user_agent=fingerprint["user_agent"],
             enable_connection_reuse=False,

--- a/tests/test_ja3_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja3_fingerprints_tlsfingerprint.py
@@ -1,10 +1,10 @@
 """
-JA3 Fingerprint Validation Tests against tlsfingerprint.com
+JA3 Fingerprint Validation Tests against tls.peet.ws
 
 Tests that CycleTLS correctly applies JA3 fingerprints by verifying the observed
-fingerprint at tlsfingerprint.com changes when different JA3 configurations are used.
+fingerprint at tls.peet.ws changes when different JA3 configurations are used.
 
-Note: Unlike ja3er.com which echoes back the JA3 we send, tlsfingerprint.com
+Note: Unlike ja3er.com which echoes back the JA3 we send, tls.peet.ws
 computes the JA3 from the actual TLS handshake. This provides more realistic
 testing of fingerprint application.
 
@@ -13,14 +13,15 @@ Skip with: pytest -m "not live"
 
 Based on: test_ja3_fingerprints.py
 """
+import os
 import pytest
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL for tlsfingerprint.com
-BASE_URL = "https://tlsfingerprint.com"
+# Base URL — override with TRACKME_URL to point at a local TrackMe instance
+BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 # Same test data as test_ja3_fingerprints.py
 JA3_FINGERPRINTS = [
@@ -47,7 +48,7 @@ JA3_FINGERPRINTS = [
 
 def extract_ja3_from_response(data: dict) -> tuple:
     """
-    Extract JA3 hash and string from tlsfingerprint.com response.
+    Extract JA3 hash and string from tls.peet.ws response.
 
     Response format:
     {
@@ -78,7 +79,7 @@ class TestJA3FingerprintApplication:
     """Test that JA3 fingerprints are correctly applied"""
 
     def test_response_contains_ja3_data(self, cycle_client):
-        """Test that tlsfingerprint.com returns JA3 data"""
+        """Test that tls.peet.ws returns JA3 data"""
         response = cycle_client.get(f"{BASE_URL}/api/all")
 
         assert response.status_code == 200
@@ -197,7 +198,7 @@ class TestJA3FingerprintDifferentiation:
 
 
 class TestChromeFingerprintsTLSFingerprint:
-    """Test Chrome browser fingerprints against tlsfingerprint.com"""
+    """Test Chrome browser fingerprints against tls.peet.ws"""
 
     def test_chrome_83(self, cycle_client):
         """Test Chrome 83 fingerprint produces valid response"""
@@ -228,7 +229,7 @@ class TestChromeFingerprintsTLSFingerprint:
 
 
 class TestFirefoxFingerprintsTLSFingerprint:
-    """Test Firefox browser fingerprints against tlsfingerprint.com"""
+    """Test Firefox browser fingerprints against tls.peet.ws"""
 
     def test_firefox_65(self, cycle_client):
         """Test Firefox 65 fingerprint produces valid response"""
@@ -259,7 +260,7 @@ class TestFirefoxFingerprintsTLSFingerprint:
 
 
 class TestSafariFingerprintsTLSFingerprint:
-    """Test Safari browser fingerprints against tlsfingerprint.com"""
+    """Test Safari browser fingerprints against tls.peet.ws"""
 
     def test_ios_17_safari(self, cycle_client):
         """Test iOS 17 Safari fingerprint produces valid response"""
@@ -289,7 +290,7 @@ class TestSafariFingerprintsTLSFingerprint:
 
 
 class TestAdditionalTLSData:
-    """Test additional TLS fingerprint data from tlsfingerprint.com"""
+    """Test additional TLS fingerprint data from tls.peet.ws"""
 
     def test_ja4_data_returned(self, cycle_client):
         """Test that JA4 fingerprint data is also returned"""
@@ -297,7 +298,7 @@ class TestAdditionalTLSData:
         assert response.status_code == 200
         data = response.json()
 
-        # tlsfingerprint.com also returns JA4 data
+        # tls.peet.ws also returns JA4 data
         assert "tls" in data
         tls = data["tls"]
 

--- a/tests/test_ja3_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja3_fingerprints_tlsfingerprint.py
@@ -68,9 +68,9 @@ def extract_ja3_from_response(data: dict) -> tuple:
     return "", ""
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def cycle_client():
-    """Create a single CycleTLS client for all tests in this module"""
+    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
     with CycleTLS() as client:
         yield client
 

--- a/tests/test_ja3_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja3_fingerprints_tlsfingerprint.py
@@ -70,8 +70,20 @@ def extract_ja3_from_response(data: dict) -> tuple:
 
 @pytest.fixture(scope="function")
 def cycle_client():
-    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
+    """Create a CycleTLS client with connection reuse disabled.
+
+    TrackMe closes connections after each request. With the default
+    enable_connection_reuse=True the Go transport caches the TLS connection
+    globally; the next test picks up the closed connection and gets
+    "use of closed network connection". Setting enable_connection_reuse=False
+    creates a fresh roundTripper per request, avoiding stale connections.
+    """
     with CycleTLS() as client:
+        _orig_request = client.request
+        def _no_reuse(method, url, **kwargs):
+            kwargs.setdefault("enable_connection_reuse", False)
+            return _orig_request(method, url, **kwargs)
+        client.request = _no_reuse
         yield client
 
 

--- a/tests/test_ja3_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja3_fingerprints_tlsfingerprint.py
@@ -14,14 +14,16 @@ Skip with: pytest -m "not live"
 Based on: test_ja3_fingerprints.py
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL — override with TRACKME_URL to point at a local TrackMe instance
-BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+# Base URL — override with TLSFP_URL to point at a local tlsfingerprint.com Docker instance
+BASE_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 # Same test data as test_ja3_fingerprints.py
 JA3_FINGERPRINTS = [
@@ -72,7 +74,7 @@ def extract_ja3_from_response(data: dict) -> tuple:
 def cycle_client():
     """Create a CycleTLS client with connection reuse disabled.
 
-    TrackMe closes connections after each request. With the default
+    tlsfingerprint.com closes connections after each request. With the default
     enable_connection_reuse=True the Go transport caches the TLS connection
     globally; the next test picks up the closed connection and gets
     "use of closed network connection". Setting enable_connection_reuse=False

--- a/tests/test_ja4_fingerprints.py
+++ b/tests/test_ja4_fingerprints.py
@@ -6,8 +6,11 @@ custom JA4_r parameters, and comparison with JA3 fingerprints.
 
 Based on: /Users/dannydasilva/Documents/personal/CycleTLS/tests/ja4-fingerprint.test.js
 """
+import os
 import pytest
 from cycletls import CycleTLS
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 @pytest.fixture(scope="module")
@@ -31,7 +34,7 @@ class TestJA4Fingerprints:
         firefox_ja4r = "t13d1717h2_002f,0035,009c,009d,1301,1302,1303,c009,c00a,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,001c,0022,0023,002b,002d,0033,fe0d,ff01_0403,0503,0603,0804,0805,0806,0401,0501,0601,0203,0201"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=firefox_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0'
@@ -70,7 +73,7 @@ class TestJA4Fingerprints:
         chrome_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
@@ -108,7 +111,7 @@ class TestJA4Fingerprints:
         chrome138_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome138_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
@@ -146,7 +149,7 @@ class TestJA4Fingerprints:
         chrome139_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome139_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36'
@@ -185,7 +188,7 @@ class TestJA4Fingerprints:
         tls12_ja4r = "t12d128h2_002f,0035,009c,009d,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0017,0023,ff01_0403,0804,0401,0503,0805,0501,0806,0601,0201"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=tls12_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
@@ -222,7 +225,7 @@ class TestJA4RawFormatParsing:
         chrome_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
         )
@@ -260,7 +263,7 @@ class TestJA4RawFormatParsing:
         tls13_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=tls13_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False  # Disable connection reuse when switching fingerprints
@@ -274,7 +277,7 @@ class TestJA4RawFormatParsing:
         tls12_ja4r = "t12d128h2_002f,0035,009c,009d,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0017,0023,ff01_0403,0804,0401,0503,0805,0501,0806,0601,0201"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=tls12_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False  # Disable connection reuse when switching fingerprints
@@ -302,14 +305,14 @@ class TestJA4vsJA3Comparison:
 
         # Test with JA3
         response_ja3 = cycle_client.get(
-            'https://tls.peet.ws/api/clean',
+            f"{_TRACKME_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent=user_agent
         )
 
         # Test with JA4R
         response_ja4 = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent=user_agent
         )
@@ -338,7 +341,7 @@ class TestJA4vsJA3Comparison:
         chrome_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False  # Disable connection reuse to avoid stale connections
@@ -369,7 +372,7 @@ class TestCustomJA4RParameter:
         custom_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=custom_ja4r,
             disable_grease=False,
             user_agent='Custom User Agent'
@@ -388,7 +391,7 @@ class TestCustomJA4RParameter:
 
         # Test with GREASE disabled - disable connection reuse when switching fingerprints
         response_no_grease = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=firefox_ja4r,
             disable_grease=True,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0',
@@ -397,7 +400,7 @@ class TestCustomJA4RParameter:
 
         # Test with GREASE enabled - disable connection reuse when switching fingerprints
         response_with_grease = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=firefox_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0',
@@ -424,14 +427,14 @@ class TestCustomJA4RParameter:
         # Make multiple requests with the same JA4_r
         # Disable connection reuse to avoid stale connections from previous tests
         response1 = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False
         )
 
         response2 = cycle_client.get(
-            'https://tls.peet.ws/api/all',
+            f"{_TRACKME_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False

--- a/tests/test_ja4_fingerprints.py
+++ b/tests/test_ja4_fingerprints.py
@@ -12,6 +12,8 @@ from cycletls import CycleTLS
 
 _TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
+pytestmark = pytest.mark.live
+
 
 @pytest.fixture(scope="module")
 def cycle_client():

--- a/tests/test_ja4_fingerprints.py
+++ b/tests/test_ja4_fingerprints.py
@@ -17,8 +17,13 @@ pytestmark = pytest.mark.live
 
 @pytest.fixture(scope="module")
 def cycle_client():
-    """Create a single CycleTLS client for all tests in this module"""
+    """Create a single CycleTLS client for all tests in this module with connection reuse disabled."""
     with CycleTLS() as client:
+        _orig = client.request
+        def _no_reuse(method, url, **kwargs):
+            kwargs.setdefault("enable_connection_reuse", False)
+            return _orig(method, url, **kwargs)
+        client.request = _no_reuse
         yield client
 
 

--- a/tests/test_ja4_fingerprints.py
+++ b/tests/test_ja4_fingerprints.py
@@ -7,10 +7,12 @@ custom JA4_r parameters, and comparison with JA3 fingerprints.
 Based on: /Users/dannydasilva/Documents/personal/CycleTLS/tests/ja4-fingerprint.test.js
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -41,7 +43,7 @@ class TestJA4Fingerprints:
         firefox_ja4r = "t13d1717h2_002f,0035,009c,009d,1301,1302,1303,c009,c00a,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,001c,0022,0023,002b,002d,0033,fe0d,ff01_0403,0503,0603,0804,0805,0806,0401,0501,0601,0203,0201"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=firefox_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0'
@@ -80,7 +82,7 @@ class TestJA4Fingerprints:
         chrome_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
@@ -118,7 +120,7 @@ class TestJA4Fingerprints:
         chrome138_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome138_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
@@ -156,7 +158,7 @@ class TestJA4Fingerprints:
         chrome139_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome139_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36'
@@ -195,7 +197,7 @@ class TestJA4Fingerprints:
         tls12_ja4r = "t12d128h2_002f,0035,009c,009d,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0017,0023,ff01_0403,0804,0401,0503,0805,0501,0806,0601,0201"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=tls12_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
@@ -232,7 +234,7 @@ class TestJA4RawFormatParsing:
         chrome_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
         )
@@ -270,7 +272,7 @@ class TestJA4RawFormatParsing:
         tls13_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=tls13_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False  # Disable connection reuse when switching fingerprints
@@ -284,7 +286,7 @@ class TestJA4RawFormatParsing:
         tls12_ja4r = "t12d128h2_002f,0035,009c,009d,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0017,0023,ff01_0403,0804,0401,0503,0805,0501,0806,0601,0201"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=tls12_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False  # Disable connection reuse when switching fingerprints
@@ -312,14 +314,14 @@ class TestJA4vsJA3Comparison:
 
         # Test with JA3
         response_ja3 = cycle_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent=user_agent
         )
 
         # Test with JA4R
         response_ja4 = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent=user_agent
         )
@@ -348,7 +350,7 @@ class TestJA4vsJA3Comparison:
         chrome_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False  # Disable connection reuse to avoid stale connections
@@ -379,7 +381,7 @@ class TestCustomJA4RParameter:
         custom_ja4r = "t13d1516h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,fe0d,ff01_0403,0804,0401,0503,0805,0501,0806,0601"
 
         response = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=custom_ja4r,
             disable_grease=False,
             user_agent='Custom User Agent'
@@ -398,7 +400,7 @@ class TestCustomJA4RParameter:
 
         # Test with GREASE disabled - disable connection reuse when switching fingerprints
         response_no_grease = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=firefox_ja4r,
             disable_grease=True,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0',
@@ -407,7 +409,7 @@ class TestCustomJA4RParameter:
 
         # Test with GREASE enabled - disable connection reuse when switching fingerprints
         response_with_grease = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=firefox_ja4r,
             disable_grease=False,
             user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0',
@@ -434,14 +436,14 @@ class TestCustomJA4RParameter:
         # Make multiple requests with the same JA4_r
         # Disable connection reuse to avoid stale connections from previous tests
         response1 = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False
         )
 
         response2 = cycle_client.get(
-            f"{_TRACKME_URL}/api/all",
+            f"{_TLSFP_URL}/api/all",
             ja4r=chrome_ja4r,
             user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
             enable_connection_reuse=False

--- a/tests/test_ja4_fingerprints.py
+++ b/tests/test_ja4_fingerprints.py
@@ -7,6 +7,7 @@ custom JA4_r parameters, and comparison with JA3 fingerprints.
 Based on: /Users/dannydasilva/Documents/personal/CycleTLS/tests/ja4-fingerprint.test.js
 """
 import os
+import re
 
 import pytest
 
@@ -15,6 +16,132 @@ from cycletls import CycleTLS
 _TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
+
+
+# JA4_r header format: t<TLS_ver>d<cipher_count><ext_count><ALPN>
+# Per the JA4 spec, cipher_count and ext_count are 2-digit zero-padded.
+# Production tls.peet.ws emits an unpadded form (e.g. "t12d128h2" for 12+8),
+# while local tlsfingerprint.com Docker emits the spec form ("t12d1208h2").
+# Both are accepted: tests validate STRUCTURE rather than exact prefixes.
+_JA4R_HEADER_RE = re.compile(r"^t(?P<ver>\d{2})d(?P<counts>\d+)(?P<alpn>h2|h1|http)$")
+
+
+def _parse_ja4r(s: str) -> dict:
+    """
+    Parse a JA4_r string into its structural components.
+
+    JA4_r format: t<ver>d<cipher_count><ext_count><ALPN>_<ciphers>_<extensions>_<sigalgs>
+
+    The cipher_count and ext_count fields in the header may be either:
+      - Unpadded (e.g. "128" -- 12 ciphers + 8 extensions, the format
+        currently produced by the production tls.peet.ws server)
+      - Zero-padded to 2 digits each (e.g. "1208" -- 12 + 08, per the JA4
+        spec, the format produced by the local tlsfingerprint.com Docker
+        server)
+
+    Note: the cipher_count and ext_count *header* fields refer to the
+    counts seen on the wire and may include SNI (0x0000) and ALPN (0x0010),
+    while the rendered extension list excludes those. So header counts will
+    NOT always equal `len(extensions)`. This helper returns the header
+    counts as ints (best-effort interpretation, preferring the spec
+    zero-padded form when ambiguous) and the observed list lengths
+    separately.
+
+    Returns a dict with keys:
+      tls_version, alpn, header_cipher_count, header_ext_count,
+      ciphers, extensions, sig_algs, header, raw.
+    """
+    parts = s.split("_")
+    assert len(parts) == 4, f"JA4_r should have 4 underscore-separated parts, got {len(parts)}: {s}"
+
+    header, ciphers_s, exts_s, sigs_s = parts
+    m = _JA4R_HEADER_RE.match(header)
+    assert m, f"JA4_r header malformed: {header!r}"
+
+    ciphers = [c for c in ciphers_s.split(",") if c]
+    extensions = [e for e in exts_s.split(",") if e]
+    sig_algs = [a for a in sigs_s.split(",") if a]
+
+    counts = m.group("counts")
+    # Decode the counts field. Spec form is 2-digit padded each (4 chars).
+    # Production tls.peet.ws strips leading zeros, so a 3-char "128" can
+    # mean 12 ciphers + 8 extensions OR 1 cipher + 28 extensions. We
+    # disambiguate by preferring the interpretation whose cipher count
+    # matches the observed cipher list length (which is invariant across
+    # servers).
+    header_cc, header_ec = _decode_counts(counts, len(ciphers))
+
+    return {
+        "tls_version": m.group("ver"),
+        "alpn": m.group("alpn"),
+        "header_cipher_count": header_cc,
+        "header_ext_count": header_ec,
+        "ciphers": ciphers,
+        "extensions": extensions,
+        "sig_algs": sig_algs,
+        "header": header,
+        "raw": s,
+    }
+
+
+def _decode_counts(counts: str, observed_cipher_count: int) -> tuple[int, int]:
+    """
+    Decode the concatenated cipher_count + ext_count field from a JA4_r
+    header. Returns (cipher_count, ext_count).
+
+    Strategy: enumerate every (cc, ec) split where cc is a prefix of
+    `counts`, prefer the split where cc equals the observed cipher count
+    (this disambiguates unpadded production output). Otherwise fall back
+    to the spec form (2-digit padded each, length 4).
+    """
+    candidates: list[tuple[int, int]] = []
+    for split in range(1, len(counts)):
+        try:
+            cc = int(counts[:split])
+            ec = int(counts[split:])
+        except ValueError:
+            continue
+        candidates.append((cc, ec))
+
+    # Prefer the candidate whose cipher count matches what we actually saw.
+    for cc, ec in candidates:
+        if cc == observed_cipher_count:
+            return cc, ec
+
+    # Fall back to the spec form (4-char zero-padded) if available.
+    if len(counts) == 4:
+        return int(counts[:2]), int(counts[2:])
+
+    # Last resort: assume single-digit cipher count.
+    if candidates:
+        return candidates[0]
+    raise AssertionError(f"Could not decode JA4_r counts field: {counts!r}")
+
+
+def _assert_ja4r_equivalent(actual: str, expected: str) -> None:
+    """
+    Assert two JA4_r strings are structurally equivalent.
+
+    Header padding for cipher_count/ext_count may differ between servers
+    (production unpadded vs spec-compliant zero-padded), but the body
+    (ciphers, extensions, signature algorithms) and TLS version + ALPN
+    must match exactly.
+    """
+    a = _parse_ja4r(actual)
+    e = _parse_ja4r(expected)
+    assert a["tls_version"] == e["tls_version"], (
+        f"TLS version mismatch: actual={a['tls_version']} expected={e['tls_version']}"
+    )
+    assert a["alpn"] == e["alpn"], f"ALPN mismatch: actual={a['alpn']} expected={e['alpn']}"
+    assert a["ciphers"] == e["ciphers"], (
+        f"Cipher list mismatch:\nactual:   {a['ciphers']}\nexpected: {e['ciphers']}"
+    )
+    assert a["extensions"] == e["extensions"], (
+        f"Extension list mismatch:\nactual:   {a['extensions']}\nexpected: {e['extensions']}"
+    )
+    assert a["sig_algs"] == e["sig_algs"], (
+        f"Signature algorithm list mismatch:\nactual:   {a['sig_algs']}\nexpected: {e['sig_algs']}"
+    )
 
 
 @pytest.fixture(scope="module")
@@ -64,13 +191,18 @@ class TestJA4Fingerprints:
         # Check for Delegated Credentials (0022)
         assert "0022" in result["tls"]["ja4_r"], "JA4_r should contain Delegated Credentials (0022)"
 
-        # Check header format - should remain t13d1717h2 (17 extensions, ALPN auto-removed)
-        assert result["tls"]["ja4_r"].startswith("t13d1717h2"), \
-            f"JA4_r should start with 't13d1717h2', got {result['tls']['ja4_r'][:11]}"
+        # Validate structure: TLS 1.3, h2 ALPN, 17 ciphers + 17 extensions.
+        # Accept both unpadded ("t13d1717h2") and zero-padded ("t13d1717h2"
+        # which already happens to coincide here) header forms.
+        parsed = _parse_ja4r(result["tls"]["ja4_r"])
+        assert parsed["tls_version"] == "13"
+        assert parsed["alpn"] == "h2"
+        assert parsed["header_cipher_count"] == 17
+        assert parsed["header_ext_count"] == 17
 
-        # Verify expected output (ALPN auto-removed since h2 in header)
-        assert result["tls"]["ja4_r"] == firefox_ja4r, \
-            f"JA4_r mismatch:\nExpected: {firefox_ja4r}\nGot: {result['tls']['ja4_r']}"
+        # Verify the cipher / extension / signature-algorithm bodies match
+        # exactly. Header padding is allowed to differ between servers.
+        _assert_ja4r_equivalent(result["tls"]["ja4_r"], firefox_ja4r)
 
     def test_chrome_ja4r_exact_match(self, cycle_client):
         """
@@ -103,13 +235,16 @@ class TestJA4Fingerprints:
         # Check for ECH extension (fe0d)
         assert "fe0d" in result["tls"]["ja4_r"], "JA4_r should contain ECH extension (fe0d)"
 
-        # Check header format
-        assert result["tls"]["ja4_r"].startswith("t13d1516h2"), \
-            f"JA4_r should start with 't13d1516h2', got {result['tls']['ja4_r'][:11]}"
+        # Validate structure: TLS 1.3, h2 ALPN, 15 ciphers + 16 extensions.
+        parsed = _parse_ja4r(result["tls"]["ja4_r"])
+        assert parsed["tls_version"] == "13"
+        assert parsed["alpn"] == "h2"
+        assert parsed["header_cipher_count"] == 15
+        assert parsed["header_ext_count"] == 16
 
-        # Verify exact match (ALPN is auto-handled with h2)
-        assert result["tls"]["ja4_r"] == chrome_ja4r, \
-            f"JA4_r mismatch:\nExpected: {chrome_ja4r}\nGot: {result['tls']['ja4_r']}"
+        # Verify body match (ALPN is auto-handled with h2). Header padding
+        # may differ across servers but ciphers/extensions/sigalgs are stable.
+        _assert_ja4r_equivalent(result["tls"]["ja4_r"], chrome_ja4r)
 
     def test_chrome_138_ja4r_exact_match(self, cycle_client):
         """
@@ -141,13 +276,15 @@ class TestJA4Fingerprints:
         # Check for ECH extension (fe0d)
         assert "fe0d" in result["tls"]["ja4_r"], "JA4_r should contain ECH extension (fe0d)"
 
-        # Check header format
-        assert result["tls"]["ja4_r"].startswith("t13d1516h2"), \
-            f"JA4_r should start with 't13d1516h2', got {result['tls']['ja4_r'][:11]}"
+        # Validate structure: TLS 1.3, h2 ALPN, 15 ciphers + 16 extensions.
+        parsed = _parse_ja4r(result["tls"]["ja4_r"])
+        assert parsed["tls_version"] == "13"
+        assert parsed["alpn"] == "h2"
+        assert parsed["header_cipher_count"] == 15
+        assert parsed["header_ext_count"] == 16
 
-        # Verify exact match
-        assert result["tls"]["ja4_r"] == chrome138_ja4r, \
-            f"JA4_r mismatch:\nExpected: {chrome138_ja4r}\nGot: {result['tls']['ja4_r']}"
+        # Body equivalence: cipher / extension / sigalg lists match exactly.
+        _assert_ja4r_equivalent(result["tls"]["ja4_r"], chrome138_ja4r)
 
     def test_chrome_139_ja4r_exact_match(self, cycle_client):
         """
@@ -179,13 +316,15 @@ class TestJA4Fingerprints:
         # Check for ECH extension (fe0d)
         assert "fe0d" in result["tls"]["ja4_r"], "JA4_r should contain ECH extension (fe0d)"
 
-        # Check header format
-        assert result["tls"]["ja4_r"].startswith("t13d1516h2"), \
-            f"JA4_r should start with 't13d1516h2', got {result['tls']['ja4_r'][:11]}"
+        # Validate structure: TLS 1.3, h2 ALPN, 15 ciphers + 16 extensions.
+        parsed = _parse_ja4r(result["tls"]["ja4_r"])
+        assert parsed["tls_version"] == "13"
+        assert parsed["alpn"] == "h2"
+        assert parsed["header_cipher_count"] == 15
+        assert parsed["header_ext_count"] == 16
 
-        # Verify exact match
-        assert result["tls"]["ja4_r"] == chrome139_ja4r, \
-            f"JA4_r mismatch:\nExpected: {chrome139_ja4r}\nGot: {result['tls']['ja4_r']}"
+        # Body equivalence: cipher / extension / sigalg lists match exactly.
+        _assert_ja4r_equivalent(result["tls"]["ja4_r"], chrome139_ja4r)
 
     def test_tls12_ja4r_exact_match(self, cycle_client):
         """
@@ -212,13 +351,21 @@ class TestJA4Fingerprints:
         assert "ja4_r" in result["tls"], "TLS data should contain 'ja4_r' field"
         assert result.get("http_version") == "h2", f"Expected HTTP/2, got {result.get('http_version')}"
 
-        # TLS 1.2 response should be t12d128h2 (8 extensions with h2, ALPN auto-handled)
-        assert result["tls"]["ja4_r"].startswith("t12d128h2"), \
-            f"JA4_r should start with 't12d128h2', got {result['tls']['ja4_r'][:10]}"
+        # Validate structure: TLS 1.2, h2 ALPN, 12 ciphers + 8 extensions.
+        # Production tls.peet.ws emits the unpadded "t12d128h2" form, while
+        # local tlsfingerprint.com Docker emits the spec-compliant
+        # zero-padded "t12d1208h2" form. Both are accepted.
+        parsed = _parse_ja4r(result["tls"]["ja4_r"])
+        assert parsed["tls_version"] == "12", (
+            f"Expected TLS 1.2, got version {parsed['tls_version']!r} "
+            f"in {result['tls']['ja4_r']!r}"
+        )
+        assert parsed["alpn"] == "h2"
+        assert parsed["header_cipher_count"] == 12
+        assert parsed["header_ext_count"] == 8
 
-        # Verify exact match
-        assert result["tls"]["ja4_r"] == tls12_ja4r, \
-            f"JA4_r mismatch:\nExpected: {tls12_ja4r}\nGot: {result['tls']['ja4_r']}"
+        # Body equivalence: cipher / extension / sigalg lists match exactly.
+        _assert_ja4r_equivalent(result["tls"]["ja4_r"], tls12_ja4r)
 
 
 class TestJA4RawFormatParsing:
@@ -390,9 +537,10 @@ class TestCustomJA4RParameter:
         assert response.status_code == 200
         result = response.json()
 
-        # Verify the custom JA4_r was used
-        assert result["tls"]["ja4_r"] == custom_ja4r, \
-            "Response should contain the custom JA4_r parameter"
+        # Verify the custom JA4_r was used (header padding may differ between
+        # production tls.peet.ws and the local Docker server, so compare the
+        # cipher / extension / sigalg bodies rather than the exact string).
+        _assert_ja4r_equivalent(result["tls"]["ja4_r"], custom_ja4r)
 
     def test_ja4r_with_disable_grease(self, cycle_client):
         """Test JA4_r with GREASE disabled"""
@@ -455,8 +603,10 @@ class TestCustomJA4RParameter:
         data1 = response1.json()
         data2 = response2.json()
 
-        # Verify consistency
+        # Verify consistency: the same server should produce identical
+        # JA4_r strings across requests. Both responses should also be
+        # structurally equivalent to the input fingerprint (header padding
+        # may differ between servers but ciphers/extensions/sigalgs are stable).
         assert data1["tls"]["ja4_r"] == data2["tls"]["ja4_r"], \
             "Multiple requests with same JA4_r should return consistent results"
-        assert data1["tls"]["ja4_r"] == chrome_ja4r, \
-            "JA4_r should match the input parameter"
+        _assert_ja4r_equivalent(data1["tls"]["ja4_r"], chrome_ja4r)

--- a/tests/test_ja4_fingerprints.py
+++ b/tests/test_ja4_fingerprints.py
@@ -7,141 +7,25 @@ custom JA4_r parameters, and comparison with JA3 fingerprints.
 Based on: /Users/dannydasilva/Documents/personal/CycleTLS/tests/ja4-fingerprint.test.js
 """
 import os
-import re
 
 import pytest
+
+# Structural JA4_r matchers live in tests/conftest.py so they can be reused by
+# test_tlsfingerprint_blocking.py. See conftest for full rationale on why we
+# match structure rather than exact strings (production tls.peet.ws strips
+# leading zeros in the cipher_count/ext_count header field).
+from conftest import (
+    assert_ja4r_equivalent as _assert_ja4r_equivalent,
+)
+from conftest import (
+    parse_ja4r as _parse_ja4r,
+)
 
 from cycletls import CycleTLS
 
 _TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
-
-
-# JA4_r header format: t<TLS_ver>d<cipher_count><ext_count><ALPN>
-# Per the JA4 spec, cipher_count and ext_count are 2-digit zero-padded.
-# Production tls.peet.ws emits an unpadded form (e.g. "t12d128h2" for 12+8),
-# while local tlsfingerprint.com Docker emits the spec form ("t12d1208h2").
-# Both are accepted: tests validate STRUCTURE rather than exact prefixes.
-_JA4R_HEADER_RE = re.compile(r"^t(?P<ver>\d{2})d(?P<counts>\d+)(?P<alpn>h2|h1|http)$")
-
-
-def _parse_ja4r(s: str) -> dict:
-    """
-    Parse a JA4_r string into its structural components.
-
-    JA4_r format: t<ver>d<cipher_count><ext_count><ALPN>_<ciphers>_<extensions>_<sigalgs>
-
-    The cipher_count and ext_count fields in the header may be either:
-      - Unpadded (e.g. "128" -- 12 ciphers + 8 extensions, the format
-        currently produced by the production tls.peet.ws server)
-      - Zero-padded to 2 digits each (e.g. "1208" -- 12 + 08, per the JA4
-        spec, the format produced by the local tlsfingerprint.com Docker
-        server)
-
-    Note: the cipher_count and ext_count *header* fields refer to the
-    counts seen on the wire and may include SNI (0x0000) and ALPN (0x0010),
-    while the rendered extension list excludes those. So header counts will
-    NOT always equal `len(extensions)`. This helper returns the header
-    counts as ints (best-effort interpretation, preferring the spec
-    zero-padded form when ambiguous) and the observed list lengths
-    separately.
-
-    Returns a dict with keys:
-      tls_version, alpn, header_cipher_count, header_ext_count,
-      ciphers, extensions, sig_algs, header, raw.
-    """
-    parts = s.split("_")
-    assert len(parts) == 4, f"JA4_r should have 4 underscore-separated parts, got {len(parts)}: {s}"
-
-    header, ciphers_s, exts_s, sigs_s = parts
-    m = _JA4R_HEADER_RE.match(header)
-    assert m, f"JA4_r header malformed: {header!r}"
-
-    ciphers = [c for c in ciphers_s.split(",") if c]
-    extensions = [e for e in exts_s.split(",") if e]
-    sig_algs = [a for a in sigs_s.split(",") if a]
-
-    counts = m.group("counts")
-    # Decode the counts field. Spec form is 2-digit padded each (4 chars).
-    # Production tls.peet.ws strips leading zeros, so a 3-char "128" can
-    # mean 12 ciphers + 8 extensions OR 1 cipher + 28 extensions. We
-    # disambiguate by preferring the interpretation whose cipher count
-    # matches the observed cipher list length (which is invariant across
-    # servers).
-    header_cc, header_ec = _decode_counts(counts, len(ciphers))
-
-    return {
-        "tls_version": m.group("ver"),
-        "alpn": m.group("alpn"),
-        "header_cipher_count": header_cc,
-        "header_ext_count": header_ec,
-        "ciphers": ciphers,
-        "extensions": extensions,
-        "sig_algs": sig_algs,
-        "header": header,
-        "raw": s,
-    }
-
-
-def _decode_counts(counts: str, observed_cipher_count: int) -> tuple[int, int]:
-    """
-    Decode the concatenated cipher_count + ext_count field from a JA4_r
-    header. Returns (cipher_count, ext_count).
-
-    Strategy: enumerate every (cc, ec) split where cc is a prefix of
-    `counts`, prefer the split where cc equals the observed cipher count
-    (this disambiguates unpadded production output). Otherwise fall back
-    to the spec form (2-digit padded each, length 4).
-    """
-    candidates: list[tuple[int, int]] = []
-    for split in range(1, len(counts)):
-        try:
-            cc = int(counts[:split])
-            ec = int(counts[split:])
-        except ValueError:
-            continue
-        candidates.append((cc, ec))
-
-    # Prefer the candidate whose cipher count matches what we actually saw.
-    for cc, ec in candidates:
-        if cc == observed_cipher_count:
-            return cc, ec
-
-    # Fall back to the spec form (4-char zero-padded) if available.
-    if len(counts) == 4:
-        return int(counts[:2]), int(counts[2:])
-
-    # Last resort: assume single-digit cipher count.
-    if candidates:
-        return candidates[0]
-    raise AssertionError(f"Could not decode JA4_r counts field: {counts!r}")
-
-
-def _assert_ja4r_equivalent(actual: str, expected: str) -> None:
-    """
-    Assert two JA4_r strings are structurally equivalent.
-
-    Header padding for cipher_count/ext_count may differ between servers
-    (production unpadded vs spec-compliant zero-padded), but the body
-    (ciphers, extensions, signature algorithms) and TLS version + ALPN
-    must match exactly.
-    """
-    a = _parse_ja4r(actual)
-    e = _parse_ja4r(expected)
-    assert a["tls_version"] == e["tls_version"], (
-        f"TLS version mismatch: actual={a['tls_version']} expected={e['tls_version']}"
-    )
-    assert a["alpn"] == e["alpn"], f"ALPN mismatch: actual={a['alpn']} expected={e['alpn']}"
-    assert a["ciphers"] == e["ciphers"], (
-        f"Cipher list mismatch:\nactual:   {a['ciphers']}\nexpected: {e['ciphers']}"
-    )
-    assert a["extensions"] == e["extensions"], (
-        f"Extension list mismatch:\nactual:   {a['extensions']}\nexpected: {e['extensions']}"
-    )
-    assert a["sig_algs"] == e["sig_algs"], (
-        f"Signature algorithm list mismatch:\nactual:   {a['sig_algs']}\nexpected: {e['sig_algs']}"
-    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_ja4_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja4_fingerprints_tlsfingerprint.py
@@ -1,22 +1,23 @@
 """
-JA4 Fingerprint Validation Tests against tlsfingerprint.com
+JA4 Fingerprint Validation Tests against tls.peet.ws
 
 Tests JA4 and JA4_r fingerprinting functionality by verifying the observed
-fingerprints at tlsfingerprint.com when different JA4_r configurations are used.
+fingerprints at tls.peet.ws when different JA4_r configurations are used.
 
 Run with: pytest tests/test_ja4_fingerprints_tlsfingerprint.py -v -m live
 Skip with: pytest -m "not live"
 
 Based on: test_ja4_fingerprints.py
 """
+import os
 import pytest
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL for tlsfingerprint.com
-BASE_URL = "https://tlsfingerprint.com"
+# Base URL — override with TRACKME_URL to point at a local TrackMe instance
+BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 # JA4_r fingerprints from test_ja4_fingerprints.py
 JA4R_FINGERPRINTS = [
@@ -45,7 +46,7 @@ JA4R_FINGERPRINTS = [
 
 def extract_ja4_from_response(data: dict) -> dict:
     """
-    Extract JA4 data from tlsfingerprint.com response.
+    Extract JA4 data from tls.peet.ws response.
 
     Response format:
     {
@@ -81,7 +82,7 @@ class TestJA4FingerprintApplication:
     """Test that JA4 fingerprints are correctly applied"""
 
     def test_response_contains_ja4_data(self, cycle_client):
-        """Test that tlsfingerprint.com returns JA4 data"""
+        """Test that tls.peet.ws returns JA4 data"""
         response = cycle_client.get(f"{BASE_URL}/api/all")
 
         assert response.status_code == 200

--- a/tests/test_ja4_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja4_fingerprints_tlsfingerprint.py
@@ -71,9 +71,9 @@ def extract_ja4_from_response(data: dict) -> dict:
     return {}
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def cycle_client():
-    """Create a single CycleTLS client for all tests in this module"""
+    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
     with CycleTLS() as client:
         yield client
 

--- a/tests/test_ja4_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja4_fingerprints_tlsfingerprint.py
@@ -73,8 +73,20 @@ def extract_ja4_from_response(data: dict) -> dict:
 
 @pytest.fixture(scope="function")
 def cycle_client():
-    """Create a fresh CycleTLS client for each test (TrackMe closes connections after each request)"""
+    """Create a CycleTLS client with connection reuse disabled.
+
+    TrackMe closes connections after each request. With the default
+    enable_connection_reuse=True the Go transport caches the TLS connection
+    globally; the next test picks up the closed connection and gets
+    "use of closed network connection". Setting enable_connection_reuse=False
+    creates a fresh roundTripper per request, avoiding stale connections.
+    """
     with CycleTLS() as client:
+        _orig_request = client.request
+        def _no_reuse(method, url, **kwargs):
+            kwargs.setdefault("enable_connection_reuse", False)
+            return _orig_request(method, url, **kwargs)
+        client.request = _no_reuse
         yield client
 
 

--- a/tests/test_ja4_fingerprints_tlsfingerprint.py
+++ b/tests/test_ja4_fingerprints_tlsfingerprint.py
@@ -10,14 +10,16 @@ Skip with: pytest -m "not live"
 Based on: test_ja4_fingerprints.py
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
 # Mark all tests in this module as live tests
 pytestmark = pytest.mark.live
 
-# Base URL — override with TRACKME_URL to point at a local TrackMe instance
-BASE_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+# Base URL — override with TLSFP_URL to point at a local tlsfingerprint.com Docker instance
+BASE_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 # JA4_r fingerprints from test_ja4_fingerprints.py
 JA4R_FINGERPRINTS = [
@@ -75,7 +77,7 @@ def extract_ja4_from_response(data: dict) -> dict:
 def cycle_client():
     """Create a CycleTLS client with connection reuse disabled.
 
-    TrackMe closes connections after each request. With the default
+    tlsfingerprint.com closes connections after each request. With the default
     enable_connection_reuse=True the Go transport caches the TLS connection
     globally; the next test picks up the closed connection and gets
     "use of closed network connection". Setting enable_connection_reuse=False

--- a/tests/test_module_api.py
+++ b/tests/test_module_api.py
@@ -5,9 +5,12 @@ Tests the module-level convenience functions (cycletls.get(), cycletls.post(), e
 and configuration management (set_default(), get_default(), reset_defaults()).
 """
 
+import os
 import pytest
 import cycletls
 from cycletls import HTTPError
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -321,7 +324,7 @@ class TestTLSFingerprintingWithModuleAPI:
         """Test using JA3 fingerprint as default"""
         cycletls.set_default(ja3=chrome_ja3)
 
-        response = cycletls.get("https://tls.peet.ws/api/clean")
+        response = cycletls.get(f"{_TRACKME_URL}/api/clean")
 
         assert response.status_code == 200
         data = response.json()
@@ -329,7 +332,7 @@ class TestTLSFingerprintingWithModuleAPI:
 
     def test_ja3_fingerprint_per_request(self, firefox_ja3):
         """Test using JA3 fingerprint per-request"""
-        response = cycletls.get("https://tls.peet.ws/api/clean", ja3=firefox_ja3)
+        response = cycletls.get(f"{_TRACKME_URL}/api/clean", ja3=firefox_ja3)
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_module_api.py
+++ b/tests/test_module_api.py
@@ -314,6 +314,9 @@ class TestTLSFingerprintingWithModuleAPI:
     def setup_method(self):
         """Reset defaults before each test"""
         cycletls.reset_defaults()
+        # TrackMe closes connections after each request; disable reuse to avoid
+        # "use of closed network connection" from the global Go transport pool.
+        cycletls.set_default(enable_connection_reuse=False)
 
     def teardown_method(self):
         """Clean up after each test"""

--- a/tests/test_module_api.py
+++ b/tests/test_module_api.py
@@ -6,11 +6,13 @@ and configuration management (set_default(), get_default(), reset_defaults()).
 """
 
 import os
+
 import pytest
+
 import cycletls
 from cycletls import HTTPError
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -314,7 +316,7 @@ class TestTLSFingerprintingWithModuleAPI:
     def setup_method(self):
         """Reset defaults before each test"""
         cycletls.reset_defaults()
-        # TrackMe closes connections after each request; disable reuse to avoid
+        # tlsfingerprint.com closes connections after each request; disable reuse to avoid
         # "use of closed network connection" from the global Go transport pool.
         cycletls.set_default(enable_connection_reuse=False)
 
@@ -327,7 +329,7 @@ class TestTLSFingerprintingWithModuleAPI:
         """Test using JA3 fingerprint as default"""
         cycletls.set_default(ja3=chrome_ja3)
 
-        response = cycletls.get(f"{_TRACKME_URL}/api/clean")
+        response = cycletls.get(f"{_TLSFP_URL}/api/clean")
 
         assert response.status_code == 200
         data = response.json()
@@ -335,7 +337,7 @@ class TestTLSFingerprintingWithModuleAPI:
 
     def test_ja3_fingerprint_per_request(self, firefox_ja3):
         """Test using JA3 fingerprint per-request"""
-        response = cycletls.get(f"{_TRACKME_URL}/api/clean", ja3=firefox_ja3)
+        response = cycletls.get(f"{_TLSFP_URL}/api/clean", ja3=firefox_ja3)
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_tls13.py
+++ b/tests/test_tls13.py
@@ -11,9 +11,12 @@ Based on CycleTLS Go integration tests (tls_13_test.go), these tests verify:
 Uses various HTTPS sites that support TLS 1.3 for testing.
 """
 
+import os
 import pytest
 import json
 from test_utils import assert_valid_response
+
+_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -195,7 +198,7 @@ class TestTLS12Fallback:
         # Using reliable endpoints only (howsmyssl.com is flaky)
         endpoints = [
             "https://httpbin.org/get",
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
         ]
 
         for endpoint in endpoints:
@@ -255,7 +258,7 @@ class TestTLS13WithJa3er:
         """Test that TLS 1.3 fingerprint is correctly applied."""
         # Use tls.peet.ws instead of ja3er.com (more reliable)
         response = cycletls_client.get(
-            "https://tls.peet.ws/api/clean",
+            f"{_TRACKME_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
             timeout=30

--- a/tests/test_tls13.py
+++ b/tests/test_tls13.py
@@ -206,6 +206,7 @@ class TestTLS12Fallback:
                 endpoint,
                 ja3=firefox_ja3,
                 user_agent="Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
+                enable_connection_reuse=False,
                 timeout=30
             )
 
@@ -261,6 +262,7 @@ class TestTLS13WithJa3er:
             f"{_TRACKME_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
+            enable_connection_reuse=False,
             timeout=30
         )
 

--- a/tests/test_tls13.py
+++ b/tests/test_tls13.py
@@ -11,12 +11,13 @@ Based on CycleTLS Go integration tests (tls_13_test.go), these tests verify:
 Uses various HTTPS sites that support TLS 1.3 for testing.
 """
 
-import os
-import pytest
 import json
+import os
+
+import pytest
 from test_utils import assert_valid_response
 
-_TRACKME_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+_TLSFP_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 pytestmark = pytest.mark.live
 
@@ -198,7 +199,7 @@ class TestTLS12Fallback:
         # Using reliable endpoints only (howsmyssl.com is flaky)
         endpoints = [
             "https://httpbin.org/get",
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
         ]
 
         for endpoint in endpoints:
@@ -247,7 +248,7 @@ class TestTLS13ErrorHandling:
             )
             # If it succeeds, library fell back to default fingerprint
             assert hasattr(response, 'status_code'), "Response should have status_code"
-        except Exception as e:
+        except Exception:
             # Expected to fail with invalid JA3
             assert True, "Invalid JA3 should either fail or fall back to default"
 
@@ -259,7 +260,7 @@ class TestTLS13WithJa3er:
         """Test that TLS 1.3 fingerprint is correctly applied."""
         # Use tls.peet.ws instead of ja3er.com (more reliable)
         response = cycletls_client.get(
-            f"{_TRACKME_URL}/api/clean",
+            f"{_TLSFP_URL}/api/clean",
             ja3=chrome_ja3,
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
             enable_connection_reuse=False,

--- a/tests/test_tlsfingerprint_blocking.py
+++ b/tests/test_tlsfingerprint_blocking.py
@@ -23,14 +23,15 @@ Based on CycleTLS TypeScript tests:
 - tests/http2-fingerprint.test.js
 - tests/tlsfingerprint/basic.test.ts
 """
+import os
 import pytest
 from cycletls import CycleTLS
 
 # Mark all tests in this module as blocking (CI-critical)
 pytestmark = [pytest.mark.blocking, pytest.mark.live]
 
-# Primary test URL - tls.peet.ws is most reliable
-PEET_WS_URL = "https://tls.peet.ws"
+# Primary test URL — override with TRACKME_URL to point at a local TrackMe instance
+PEET_WS_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
 
 
 # ==============================================================================

--- a/tests/test_tlsfingerprint_blocking.py
+++ b/tests/test_tlsfingerprint_blocking.py
@@ -24,14 +24,16 @@ Based on CycleTLS TypeScript tests:
 - tests/tlsfingerprint/basic.test.ts
 """
 import os
+
 import pytest
+
 from cycletls import CycleTLS
 
 # Mark all tests in this module as blocking (CI-critical)
 pytestmark = [pytest.mark.blocking, pytest.mark.live]
 
-# Primary test URL — override with TRACKME_URL to point at a local TrackMe instance
-PEET_WS_URL = os.environ.get("TRACKME_URL", "https://tls.peet.ws")
+# Primary test URL — override with TLSFP_URL to point at a local tlsfingerprint.com Docker instance
+PEET_WS_URL = os.environ.get("TLSFP_URL", "https://tls.peet.ws")
 
 
 # ==============================================================================
@@ -573,7 +575,7 @@ class TestFingerprintConsistencyBlocking:
         # All JA4_r values should match
         ja4r_values = [resp.json()["tls"]["ja4_r"] for resp in responses]
         assert all(v == ja4r_values[0] for v in ja4r_values), (
-            f"JA4_r values should be consistent across requests:\n"
+            "JA4_r values should be consistent across requests:\n"
             + "\n".join(f"Request {i+1}: {v}" for i, v in enumerate(ja4r_values))
         )
 

--- a/tests/test_tlsfingerprint_blocking.py
+++ b/tests/test_tlsfingerprint_blocking.py
@@ -27,6 +27,14 @@ import os
 
 import pytest
 
+# Structural JA4_r matchers (see tests/conftest.py for full rationale).
+# Production tls.peet.ws strips leading zeros from the cipher_count/ext_count
+# header field (e.g. "t12d128h2" for 12 ciphers + 8 extensions), while the
+# local tlsfingerprint.com Docker image used by CI emits the spec-compliant
+# zero-padded form ("t12d1208h2"). We assert structural equivalence rather
+# than exact string equality so tests pass against either backend.
+from conftest import assert_ja4r_equivalent
+
 from cycletls import CycleTLS
 
 # Mark all tests in this module as blocking (CI-critical)
@@ -234,11 +242,10 @@ class TestJA4FingerprintBlocking:
         data = response.json()
 
         observed_ja4r = data["tls"]["ja4_r"]
-        assert observed_ja4r == self.CHROME_JA4R, (
-            f"JA4_r mismatch:\n"
-            f"Expected: {self.CHROME_JA4R}\n"
-            f"Observed: {observed_ja4r}"
-        )
+        # Structural match: header padding may differ between production and
+        # local tlsfingerprint.com servers, but ciphers/extensions/sigalgs
+        # must match exactly.
+        assert_ja4r_equivalent(observed_ja4r, self.CHROME_JA4R)
 
     def test_ja4r_firefox_fingerprint_exact_match(self, cycle_client):
         """
@@ -260,11 +267,8 @@ class TestJA4FingerprintBlocking:
         data = response.json()
 
         observed_ja4r = data["tls"]["ja4_r"]
-        assert observed_ja4r == self.FIREFOX_JA4R, (
-            f"JA4_r mismatch:\n"
-            f"Expected: {self.FIREFOX_JA4R}\n"
-            f"Observed: {observed_ja4r}"
-        )
+        # Structural match: see CHROME variant above.
+        assert_ja4r_equivalent(observed_ja4r, self.FIREFOX_JA4R)
 
     def test_ja4r_tls12_fingerprint_exact_match(self, cycle_client):
         """
@@ -286,11 +290,10 @@ class TestJA4FingerprintBlocking:
         data = response.json()
 
         observed_ja4r = data["tls"]["ja4_r"]
-        assert observed_ja4r == self.TLS12_JA4R, (
-            f"JA4_r mismatch:\n"
-            f"Expected: {self.TLS12_JA4R}\n"
-            f"Observed: {observed_ja4r}"
-        )
+        # TLS 1.2 is the case where production vs local server header padding
+        # actually diverges: production emits "t12d128h2" (12+8 unpadded),
+        # local Docker emits "t12d1208h2" (12+08 spec-padded). Body is stable.
+        assert_ja4r_equivalent(observed_ja4r, self.TLS12_JA4R)
 
     def test_ja4r_header_format_chrome(self, cycle_client):
         """
@@ -508,7 +511,8 @@ class TestCombinedFingerprintsBlocking:
         # Verify TLS fingerprint
         assert "tls" in data, "Response should contain TLS data"
         assert "ja4_r" in data["tls"], "TLS data should contain ja4_r"
-        assert data["tls"]["ja4_r"] == self.CHROME_JA4R, "JA4_r should match"
+        # Structural match: header padding may differ between servers.
+        assert_ja4r_equivalent(data["tls"]["ja4_r"], self.CHROME_JA4R)
 
         # Verify HTTP/2 fingerprint
         assert "http2" in data, "Response should contain HTTP/2 data"
@@ -579,12 +583,9 @@ class TestFingerprintConsistencyBlocking:
             + "\n".join(f"Request {i+1}: {v}" for i, v in enumerate(ja4r_values))
         )
 
-        # All should match expected value
-        assert ja4r_values[0] == self.CHROME_JA4R, (
-            f"JA4_r should match expected value:\n"
-            f"Expected: {self.CHROME_JA4R}\n"
-            f"Observed: {ja4r_values[0]}"
-        )
+        # All should match expected value (structural match: header padding
+        # may differ between production and local servers).
+        assert_ja4r_equivalent(ja4r_values[0], self.CHROME_JA4R)
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
Adapts the local-Docker live-tests pattern from #43 (smeinecke), but uses Danny-Dasilva/tlsfingerprint.com (the source of `tls.peet.ws`) instead of the third-party TrackMe image. This keeps the test infrastructure under our control and ensures response-shape parity with the production endpoint we already test against.

Tests fall back to `https://tls.peet.ws` when `TLSFP_URL` is unset (CI uses the local container; local dev defaults to production).

Co-authored-by: Stefan Meinecke (test-pattern inspiration from #43)

## How it works
- CI workflow clones Danny-Dasilva/tlsfingerprint.com@master, generates self-signed certs, builds + runs the Docker container with NET_ADMIN/NET_RAW caps, then runs the live-tests pytest matrix against `https://localhost`.
- Tests use `TLSFP_URL` env var (default: `https://tls.peet.ws`).
- smeinecke's six commits are preserved with original authorship; the env-var rename and Docker swap are committed as Danny-Dasilva.

## Test Plan
- [ ] CI green on local-Docker run
- [ ] Backward-compat: omitting TLSFP_URL falls back to tls.peet.ws and tests still pass
- [x] `uv run ruff check tests/` clean
- [x] `uv run pytest tests/ --collect-only` clean (1187 tests collected)
