### PR TITLE
fix(transport): propagate enable_connection_reuse=False as DisableKeepAlives=true

### DIFF
--- a/golang/client.go
+++ b/golang/client.go
@@ -94,6 +94,14 @@ type Browser struct {
 	ForceHTTP1         bool
 	ForceHTTP3         bool
 
+	// DisableKeepAlives, when true, disables HTTP keep-alives at the
+	// inner http.Transport layer for every request that uses this Browser.
+	// Set this when the caller passes enable_connection_reuse=false from
+	// Python so that connection reuse really is disabled — bypassing the
+	// global client cache alone is not sufficient because the underlying
+	// transport otherwise still pools idle connections per address.
+	DisableKeepAlives bool
+
 	// TLS 1.3 specific options
 	TLS13AutoRetry bool
 
@@ -243,10 +251,19 @@ func generateClientKey(browser Browser, timeout int, disableRedirect bool, proxy
 	return key
 }
 
-// getOrCreateClient retrieves a client from the pool or creates a new one
+// getOrCreateClient retrieves a client from the pool or creates a new one.
+//
+// When enableConnectionReuse is false the caller wants no connection reuse
+// at all, so we both bypass the global client pool *and* propagate
+// DisableKeepAlives onto the Browser. Without the second step the inner
+// http.Transport would still pool idle conns per address — see the badssl
+// triage report at .claude/cache/agents/source-tracer/output.md for the
+// failure mode this prevents.
 func getOrCreateClient(browser Browser, timeout int, disableRedirect bool, userAgent string, enableConnectionReuse bool, proxyURL ...string) (fhttp.Client, error) {
-	// If connection reuse is disabled, always create a new client
+	// If connection reuse is disabled, always create a new client and tell
+	// the inner http.Transport to disable keep-alives.
 	if !enableConnectionReuse {
+		browser.DisableKeepAlives = true
 		return createNewClient(browser, timeout, disableRedirect, userAgent, proxyURL...)
 	}
 

--- a/golang/roundtripper.go
+++ b/golang/roundtripper.go
@@ -48,6 +48,12 @@ type roundTripper struct {
 	ForceHTTP1         bool
 	ForceHTTP3         bool
 
+	// DisableKeepAlives, when true, sets DisableKeepAlives on every
+	// inner http.Transport that this roundTripper constructs. Wired
+	// from Browser.DisableKeepAlives, which getOrCreateClient sets when
+	// the caller passes enable_connection_reuse=false.
+	DisableKeepAlives bool
+
 	// TLS 1.3 specific options
 	TLS13AutoRetry bool
 
@@ -178,7 +184,7 @@ func (rt *roundTripper) getTransport(req *http.Request, addr string) error {
 			MaxConnsPerHost:       100,
 			MaxIdleConnsPerHost:   100, // Go default is 2, which causes 98% of connections to close
 			IdleConnTimeout:       60 * time.Second,
-			DisableKeepAlives:     false,
+			DisableKeepAlives:     rt.DisableKeepAlives,
 		}
 		return nil
 	case "https":
@@ -355,7 +361,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 			MaxConnsPerHost:      100,
 			MaxIdleConnsPerHost:  100, // Go default is 2, which causes 98% of connections to close
 			IdleConnTimeout:      60 * time.Second,
-			DisableKeepAlives:    false, // Enable keep-alives for connection reuse
+			DisableKeepAlives:    rt.DisableKeepAlives, // Bound to enable_connection_reuse=False
 		}
 	}
 
@@ -457,7 +463,7 @@ func (rt *roundTripper) retryWithTLS13CompatibleCurves(ctx context.Context, netw
 			MaxConnsPerHost:      100,
 			MaxIdleConnsPerHost:  100, // Go default is 2, which causes 98% of connections to close
 			IdleConnTimeout:      60 * time.Second,
-			DisableKeepAlives:    false, // Enable keep-alives for connection reuse
+			DisableKeepAlives:    rt.DisableKeepAlives, // Bound to enable_connection_reuse=False
 		}
 	}
 
@@ -536,7 +542,7 @@ func (rt *roundTripper) retryWithOriginalTLS12JA3(ctx context.Context, network, 
 			MaxConnsPerHost:      100,
 			MaxIdleConnsPerHost:  100, // Go default is 2, which causes 98% of connections to close
 			IdleConnTimeout:      60 * time.Second,
-			DisableKeepAlives:    false, // Enable keep-alives for connection reuse
+			DisableKeepAlives:    rt.DisableKeepAlives, // Bound to enable_connection_reuse=False
 		}
 	}
 
@@ -637,6 +643,7 @@ func newRoundTripper(browser Browser, dialer ...proxy.ContextDialer) http.RoundT
 		InsecureSkipVerify: browser.InsecureSkipVerify,
 		ForceHTTP1:         browser.ForceHTTP1,
 		ForceHTTP3:         browser.ForceHTTP3,
+		DisableKeepAlives:  browser.DisableKeepAlives,
 
 		// TLS 1.3 specific options
 		TLS13AutoRetry: browser.TLS13AutoRetry,

--- a/golang/roundtripper_test.go
+++ b/golang/roundtripper_test.go
@@ -77,6 +77,76 @@ func TestNoStaleNinetySecondIdleConnTimeout(t *testing.T) {
 	}
 }
 
+// TestDisableKeepAlivesPropagatedFromBrowser asserts that the
+// DisableKeepAlives field set on the Browser struct flows through
+// newRoundTripper to the roundTripper instance.
+//
+// Background: when callers pass enable_connection_reuse=False from Python,
+// getOrCreateClient bypasses the global client cache but historically did
+// nothing else — every constructed http.Transport hardcoded
+// DisableKeepAlives: false, so the inner transport still pooled connections
+// across the same request. The flag was a half-fix.
+//
+// Wiring DisableKeepAlives onto Browser → roundTripper is the precondition
+// for the http.Transport sites picking it up; this test pins that wiring.
+func TestDisableKeepAlivesPropagatedFromBrowser(t *testing.T) {
+	rt := newRoundTripper(Browser{DisableKeepAlives: true})
+
+	rrt, ok := rt.(*roundTripper)
+	if !ok {
+		t.Fatalf("newRoundTripper returned unexpected concrete type %T", rt)
+	}
+	if !rrt.DisableKeepAlives {
+		t.Fatalf("expected DisableKeepAlives=true on roundTripper; got false")
+	}
+}
+
+// TestHTTP1TransportRespectsDisableKeepAlives constructs the HTTP-scheme
+// transport (the simplest of the 4 paths — it does not require a real TLS
+// handshake) and asserts that DisableKeepAlives is honoured.
+func TestHTTP1TransportRespectsDisableKeepAlives(t *testing.T) {
+	rt := newRoundTripper(Browser{DisableKeepAlives: true}).(*roundTripper)
+
+	// The "http" scheme branch in getTransport constructs an http.Transport
+	// directly without doing any I/O. We bypass dialTLS by going through the
+	// branch under test.
+	req, _ := http.NewRequest("GET", "http://example.test/", nil)
+	if err := rt.getTransport(req, "example.test:80"); err != nil {
+		t.Fatalf("getTransport(http) unexpectedly returned error: %v", err)
+	}
+	tr, ok := rt.cachedTransports["example.test:80"].(*http.Transport)
+	if !ok {
+		t.Fatalf("cachedTransport is not *http.Transport: %T", rt.cachedTransports["example.test:80"])
+	}
+	if !tr.DisableKeepAlives {
+		t.Fatalf("expected DisableKeepAlives=true on the constructed http.Transport; got false")
+	}
+}
+
+// TestSourcePropagatesDisableKeepAlivesToAllFourTransports pins the
+// invariant that all 4 http.Transport literals in roundtripper.go carry a
+// DisableKeepAlives entry that is bound to rt.DisableKeepAlives — not the
+// hardcoded false. We assert this at the source level because three of the
+// four constructions are nested inside dialTLS / TLS-retry paths that
+// require live network I/O to reach.
+func TestSourcePropagatesDisableKeepAlivesToAllFourTransports(t *testing.T) {
+	src := readRoundTripperSource(t)
+
+	// All DisableKeepAlives lines under an http.Transport literal should
+	// reference rt.DisableKeepAlives (not the literal `false`).
+	hardcoded := regexp.MustCompile(`DisableKeepAlives:\s*false\b`)
+	if hardcoded.MatchString(src) {
+		t.Errorf("found hardcoded DisableKeepAlives: false — must be bound to rt.DisableKeepAlives so enable_connection_reuse=False propagates through")
+	}
+
+	// And there must be at least 4 references to rt.DisableKeepAlives, one
+	// per http.Transport literal.
+	bound := regexp.MustCompile(`DisableKeepAlives:\s*rt\.DisableKeepAlives\b`)
+	if got := len(bound.FindAllString(src, -1)); got < 4 {
+		t.Errorf("expected at least 4 DisableKeepAlives: rt.DisableKeepAlives bindings (HTTP scheme + HTTP/1 + 2 retry paths); got %d", got)
+	}
+}
+
 // (sanity check) the http import is referenced so that gofmt/imports does
 // not strip it if other tests are removed in the future.
 var _ = http.MethodGet


### PR DESCRIPTION
## Summary
`enable_connection_reuse=False` was a half-fix: it bypassed the global `fhttp.Client` cache but the new transport still hardcoded `DisableKeepAlives: false`. Tests that turned reuse off were still doing keep-alive at the transport level, so they remained vulnerable to the idle-pool race.

**Fix:** plumb the flag through to all 4 `http.Transport` constructions in `golang/roundtripper.go` and set `DisableKeepAlives: true` when reuse is disabled. Wires from `golang/client.go` to roundtripper.

## Why
Confirmed by the source-tracer investigator. Without this, the existing `enable_connection_reuse=False` workaround (used by PR #44 and `test_ja3_fingerprints.py`) provides only weak protection — connections still go into an idle pool, just a freshly-created one per call.

## Stacked on #51
This branch is stacked on top of `fix/idle-conn-timeout` (PR #51) because both fixes touch the same struct fields in `roundtripper.go`. After #51 merges, GitHub will retarget this PR's diff cleanly.

## Test plan
- [x] `go test -run TestDisableKeepAlivesPropagatedFromBrowser` (new test asserts the flag flows from browser config to transport)
- [x] No regressions in existing Go tests

Part of the badssl-flake remediation series.
