### PR TITLE
feat(extensions): expose all utls TLS extensions in genMap parrot map

### DIFF
--- a/golang/utils.go
+++ b/golang/utils.go
@@ -933,7 +933,7 @@ func genMap(disableGrease bool) (extMap map[string]utls.TLSExtension) {
 		"16": &utls.ALPNExtension{
 			AlpnProtocols: []string{"h2", "http/1.1"},
 		},
-		"17": &utls.GenericExtension{Id: 17}, // status_request_v2
+		"17": &utls.StatusRequestV2Extension{}, // status_request_v2 (17)
 		"18": &utls.SCTExtension{},
 		"21": &utls.UtlsPaddingExtension{GetPaddingLen: utls.BoringPaddingStyle},
 		"22": &utls.GenericExtension{Id: 22}, // encrypt_then_mac
@@ -999,11 +999,12 @@ func genMap(disableGrease bool) (extMap map[string]utls.TLSExtension) {
 				"h2",
 			},
 		},
-		"17613": &utls.GenericExtension{
-			Id:   17613,
-			Data: []byte{0x00, 0x03, 0x02, 0x68, 0x32},
+		"17613": &utls.ApplicationSettingsExtensionNew{
+			SupportedProtocols: []string{
+				"h2",
+			},
 		},
-		"30032": &utls.GenericExtension{Id: 0x7550, Data: []byte{0}}, // Channel ID extension
+		"30032": &utls.FakeChannelIDExtension{}, // Channel ID extension (30032 / 0x7550, new ID)
 		"65281": &utls.RenegotiationInfoExtension{
 			Renegotiation: utls.RenegotiateOnceAsClient,
 		},


### PR DESCRIPTION
## Summary

Full re-audit (not just version-delta) of utls v1.8.x extension types vs `golang/utils.go::genMap()` found three pre-existing parrot gaps that were never tied to a recent utls upgrade. Replace `GenericExtension` fallbacks with the proper utls types so the library owns the wire encoding.

## Changes (`golang/utils.go::genMap`)

| Ext ID | Before | After | Notes |
|--------|--------|-------|-------|
| `17` (status_request_v2) | `GenericExtension{Id: 17}` | `StatusRequestV2Extension{}` | RFC 6961 — utls has had this type since `v1.5.x`. Empty `GenericExtension` produced an under-spec wire blob. |
| `17613` (TLS ALPS new codepoint, `0x44cd`) | `GenericExtension{Id:17613, Data:{0x00,0x03,0x02,0x68,0x32}}` | `ApplicationSettingsExtensionNew{SupportedProtocols:["h2"]}` | utls added a dedicated type for the new ALPS codepoint; mirrors the existing `17513` mapping that already uses `ApplicationSettingsExtension`. Hand-rolled byte payload removed. |
| `30032` (Channel ID, `0x7550`) | `GenericExtension{Id:0x7550, Data:{0}}` | `FakeChannelIDExtension{}` | Real Chrome Channel ID emits **4 bytes** (id + 2-byte zero length). The previous `GenericExtension` emitted **5 bytes** (length=1, data=0x00) — this is a wire-format bug-fix as well as a parrot upgrade. |

## Intentionally unchanged (verified via re-audit)

- `10` (`SupportedCurvesExtension`), `11` (`SupportedPointsExtension`), `43` (`SupportedVersionsExtension`), `51` (`KeyShareExtension`) — populated by callers (`StringToSpec`, `QUICStringToSpec`) because their values depend on per-call inputs (TLS version, JA3 curves list, GREASE flag).
- `22` (`encrypt_then_mac`) and `49` (`post_handshake_auth`) — utls does **not** expose dedicated types for these; `GenericExtension` is the correct path.
- `65037` (`GREASE_ECH`, `0xfe0d`) — already uses `utls.BoringGREASEECH()`.
- `41` (`UtlsPreSharedKeyExtension`), `24` (`FakeTokenBindingExtension`), `28` (`FakeRecordSizeLimitExtension`), `34` (`DelegatedCredentialsExtension`), `27` (`UtlsCompressCertExtension`), `13172` (`NPNExtension`) — already mapped to proper utls types.

## What this enables

- More authentic ClientHello fingerprints for Chrome-style stacks that send `status_request_v2`, the new ALPS codepoint, or Channel ID. The wire bytes now match what Chrome actually emits.
- Future utls bugfixes/format updates flow through automatically (no hand-rolled byte arrays to maintain).

## Test plan

- [x] `go build ./...` (golang/) — passes.
- [x] `go test ./... -short` — passes (`ok github.com/Danny-Dasilva/CycleTLS/cycletls`).
- [ ] Live network smoke against `tls.peet.ws` / `tools.scrapfly.io` to confirm the on-the-wire JA3/JA4 hash for affected fingerprints matches Chrome (recommend running CI live-network suite).